### PR TITLE
Bugfixes

### DIFF
--- a/doc/30%_player_size_considerations.md
+++ b/doc/30%_player_size_considerations.md
@@ -1,0 +1,26 @@
+# Small Samus Considerations
+
+- Some players report getting nauseated
+
+- If you unmorph right as you bonk against a ceiling, you will clip through it. Don't do this on accident, but definitely do it on purpose ^_^
+    - Keep in mind, if you are in HAT without gravity suit, you will clip OoB if you simply unmorph
+
+- You need to jump through the large frigate doors to properly transition the room. If you do not, the textures will disapear around you and you will have to turn around. Be extra careful of this during frigate escape because some doors lock behind you.
+
+- Furnace spider track is
+
+- Small morph balls can get permanently stuck in Tower of Light Access
+
+- It is very easy to die in the central dynamo maze, use bomb jump to update the camera if it does not follow you. Walking through the maze is safter than rolling through it.
+
+- Life grove spinner manip doesn't work (use OoB clip and pick up from under map instead)
+
+- Early wild doesn't work (use floaty instead, or boost clip through the vines in the front entrance)
+
+- Spiderless shaft BSJ doesn't work (use OoB clip instead)
+
+- Trying to enter Elite Quarters from PCA by walking under the bars will crash the game. The workaround is to walk under the bars, scan the bars away, then reload the room.
+
+- It's possible to get stuck in the corners of the gereric connecting rooms in Chozo while in morph ball. To get out, wait a couple seconds to drop onto the floor, then roll back out away from the corner along the wall.
+
+- You can accidentally fall OoB through the floor in MQB, Security Access A, Security Access B, Control Tower elevators, and probably a few others

--- a/doc/quality_of_life.md
+++ b/doc/quality_of_life.md
@@ -33,26 +33,30 @@ These are the 5 Quality of Life categories that I've come up with and a *compreh
 
 # Level 2 - Cosmetic
 - remove all of the "wow look at samus so happy to have this cool upgrade" cutscenes (e.g. Space Jump)
-- remove all but 1 of the file select background  videos, so that during races, everyone spawns into the game at the same RTA
+- remove all but 1 of the file select background videos, so that during races, everyone spawns into the game at the same RTA
 - remove all but 1 of the attract videos to make copying the game to your wii faster
 - skip item acquisition pop-up message
 - make the morph ball HUD says `X/Y` instead of just `X`
 - If impact crater is skipped, go straight to credits instead of watching the escape sequence
 
 # Level 3 - Logical
+
 *Go Backwards*
+
+This section is broken up into each affected gameplay area:
 - Main plaza door 2-ways
 - power crashed frigate door from the back
 - scan through research lab hydra from the back
 - turn off the main quarry barrier from the back
-- remove PCA locks
-- remove EQ Access locks
-- scan through MQB barrier from the back
-- turn off MQA barrier from the back (metroid aggro trigger)
-- scan through elite control from the back
+- Go through lower mines backwards
+    - remove PCA locks
+    - remove EQ Access locks
+    - scan through MQB barrier from the back
+    - turn off MQA barrier from the back (metroid aggro trigger)
+    - scan through elite control from the back
 
 # Level 4 - Minor Cutscenes
-These are cutscenes which I think don't affect the game too much if removed.
+These are cutscenes which don't affect gameplay much if removed.
 - research lab aether
 - temple security station
 - energy core
@@ -60,7 +64,7 @@ These are cutscenes which I think don't affect the game too much if removed.
 - all of the "wow look the power is on" in frigate
 - life grove (the ghosts cutscene is left in because they just leave the map and never come back lmao)
 - main plaza
-- phendrana shorelines (just the area introduction, the ridley cutscene is left in)
+- phendrana shorelines (the ridley cutscene is left in)
 - main quarry
 - lava lake
 - tower of light
@@ -71,7 +75,7 @@ These are cutscenes which I think don't affect the game too much if removed.
 - hall of the elders (just the bomb slots cutscenes are removed)
 - crossway
 - geothermal core
-- vent shaft (the puffers hitting metal scene is left in because it doesn't work if removed)
+- vent shaft
 - chozo ice temple
 - phendrana canyon
 - ruined courtyard
@@ -91,7 +95,9 @@ Includes all of the above cutscenes and...
 - mine security station
 - elite control
 - elite research
-- central dynamo (keep the bomb jump out of the maze cutscene, otherwise, slow player will get left down there lmao)
-- mqa (but with the timing closer to reality)
+- central dynamo (kept the bomb jump out of the maze cutscene, otherwise, slow players will get left down there lmao)
+- mqa
 - elite quarters
-- all of metroid prime (I fixed exo leaving the map without needing any compromises)
+- all of metroid prime
+- hall of the elders
+- artifact temple

--- a/doc/quality_of_life.md
+++ b/doc/quality_of_life.md
@@ -85,6 +85,7 @@ These are cutscenes which don't affect gameplay much if removed.
 
 # Level 5 - Major Cutscenes
 Includes all of the above cutscenes and...
+- Arrive/Depart cutscenes for all elevators
 - landing site
 - hive totem
 - ruined shrine
@@ -101,3 +102,4 @@ Includes all of the above cutscenes and...
 - all of metroid prime
 - hall of the elders
 - artifact temple
+- end cinema

--- a/src/custom_assets.rs
+++ b/src/custom_assets.rs
@@ -322,12 +322,24 @@ pub fn custom_assets<'r>(
                     custom_asset_offset = custom_asset_offset + 1;
 
                     // Build resource //
-                    assets.extend_from_slice(&create_item_scan_strg_pair(
-                        scan_id,
-                        strg_id,
-                        format!("{}\0", scan_text).as_str(),
-                    ));
-    
+                    if room_name.trim().to_lowercase() == "research core" // make the research core scan red because it goes on the terminal
+                    {
+                        assets.extend_from_slice(&create_item_scan_strg_pair_2(
+                            scan_id,
+                            strg_id,
+                            format!("{}\0", scan_text).as_str(),
+                            1,
+                        ));
+                    }
+                    else
+                    {
+                        assets.extend_from_slice(&create_item_scan_strg_pair(
+                            scan_id,
+                            strg_id,
+                            format!("{}\0", scan_text).as_str(),
+                        ));
+                    }
+
                     // Map for easy lookup when patching //
                     let key = PickupHashKey::from_location(level_name, room_name, pickup_idx);
                     pickup_scans.insert(key, (scan_id, strg_id));
@@ -622,6 +634,16 @@ fn create_item_scan_strg_pair<'r>(
     contents: &str,
 ) -> [structs::Resource<'r>; 2]
 {
+    create_item_scan_strg_pair_2(new_scan, new_strg, contents, 0)
+}
+
+fn create_item_scan_strg_pair_2<'r>(
+    new_scan: ResId<res_id::SCAN>,
+    new_strg: ResId<res_id::STRG>,
+    contents: &str,
+    is_important: u8,
+) -> [structs::Resource<'r>; 2]
+{
     let scan = build_resource(
         new_scan,
         structs::ResourceKind::Scan(structs::Scan {
@@ -629,7 +651,7 @@ fn create_item_scan_strg_pair<'r>(
             strg: new_strg,
             scan_speed: 0,
             category: 0,
-            icon_flag: 0,
+            icon_flag: is_important,
             images: [
                 structs::ScanImage {
                     txtr: ResId::invalid(),

--- a/src/custom_assets.rs
+++ b/src/custom_assets.rs
@@ -381,6 +381,10 @@ pub fn collect_game_resources<'r>(
     looking_for.extend(PickupType::iter().map(|x| -> (_, _) { x.hudmemo_strg().into() }));
     looking_for.extend(DoorType::iter().flat_map(|x| x.dependencies()));
     looking_for.extend(BlastShieldType::iter().flat_map(|x| x.dependencies()));
+    
+    let mut deps: Vec<(u32, FourCC)> = Vec::new();
+    deps.push((0xDCEC3E77,FourCC::from_bytes(b"FRME")));
+    looking_for.extend(deps);
 
     // Dependencies read from paks and custom assets will go here //
     let mut found = HashMap::with_capacity(looking_for.len());
@@ -607,12 +611,49 @@ fn create_item_scan_strg_pair<'r>(
     let scan = build_resource(
         new_scan,
         structs::ResourceKind::Scan(structs::Scan {
-            frme: ResId::invalid(),
+            frme: ResId::<res_id::FRME>::new(0xDCEC3E77),
             strg: new_strg,
             scan_speed: 0,
             category: 0,
             icon_flag: 0,
-            images: Default::default(),
+            images: [
+                structs::ScanImage {
+                    txtr: ResId::invalid(),
+                    appearance_percent: 0.25,
+                    image_position: 0xFFFFFFFF,
+                    width: 0,
+                    height: 0,
+                    interval: 0.0,
+                    fade_duration: 0.0,
+                },
+                structs::ScanImage {
+                    txtr: ResId::invalid(),
+                    appearance_percent: 0.50,
+                    image_position: 0xFFFFFFFF,
+                    width: 0,
+                    height: 0,
+                    interval: 0.0,
+                    fade_duration: 0.0,
+                },
+                structs::ScanImage {
+                    txtr: ResId::invalid(),
+                    appearance_percent: 0.75,
+                    image_position: 0xFFFFFFFF,
+                    width: 0,
+                    height: 0,
+                    interval: 0.0,
+                    fade_duration: 0.0,
+                },
+                structs::ScanImage {
+                    txtr: ResId::invalid(),
+                    appearance_percent: 1.0,
+                    image_position: 0xFFFFFFFF,
+                    width: 0,
+                    height: 0,
+                    interval: 0.0,
+                    fade_duration: 0.0,
+                },
+            ].into(),
             padding: [255; 23].into(),
             _dummy: std::marker::PhantomData,
         }),

--- a/src/custom_assets.rs
+++ b/src/custom_assets.rs
@@ -311,7 +311,6 @@ pub fn custom_assets<'r>(
                     custom_asset_offset = custom_asset_offset + 1;
 
                     // Build resource //
-                    println!("creating scan/strg pair for {} - {}", level_name, room_name);
                     assets.extend_from_slice(&create_item_scan_strg_pair(
                         scan_id,
                         strg_id,
@@ -526,7 +525,6 @@ fn create_shiny_missile_assets<'r>(
         let cmdl_bytes = shiny_missile_cmdl.decompress().into_owned();
         let mut cmdl = Reader::new(&cmdl_bytes[..]).read::<structs::Cmdl>(());
 
-        // println!("{:#?}", cmdl);
         cmdl.material_sets.as_mut_vec()[0].texture_ids = vec![
             custom_asset_ids::SHINY_MISSILE_TXTR0,
             custom_asset_ids::SHINY_MISSILE_TXTR1,
@@ -606,7 +604,6 @@ fn create_item_scan_strg_pair<'r>(
     contents: &str,
 ) -> [structs::Resource<'r>; 2]
 {
-    println!("scan_id 0x{:X}, uses strg_id 0x{:X}", new_scan.to_u32(), new_strg.to_u32());
     let scan = build_resource(
         new_scan,
         structs::ResourceKind::Scan(structs::Scan {

--- a/src/custom_assets.rs
+++ b/src/custom_assets.rs
@@ -282,7 +282,8 @@ pub fn custom_assets<'r>(
     for (level_name, level) in config.level_data.iter() {
         for (room_name, room) in level.rooms.iter() {
             let mut pickup_idx = 0;
-            for pickup in room.pickups.iter() {
+            if room.pickups.is_none() { continue };
+            for pickup in room.pickups.as_ref().unwrap().iter() {
                 // custom hudmemo string
                 if pickup.hudmemo_text.is_some()
                 {

--- a/src/custom_assets.rs
+++ b/src/custom_assets.rs
@@ -84,6 +84,10 @@ pub mod custom_asset_ids {
         SHINY_MISSILE_ACQUIRED_HUDMEMO_STRG: STRG,
         SHINY_MISSILE_SCAN_STRG: STRG,
         SHINY_MISSILE_SCAN: SCAN,
+        SHORELINES_POI_SCAN: SCAN,
+        SHORELINES_POI_STRG: STRG,
+        MQA_POI_SCAN: SCAN,
+        MQA_POI_STRG: STRG,
         
         // Starting items memo
         STARTING_ITEMS_HUDMEMO_STRG: STRG,
@@ -268,6 +272,18 @@ pub fn custom_assets<'r>(
             "&just=center;Shiny Missile acquired!\0".to_owned(),
         ])),
     ));
+    assets.extend_from_slice(&create_item_scan_strg_pair(
+        custom_asset_ids::SHORELINES_POI_SCAN,
+        custom_asset_ids::SHORELINES_POI_STRG,
+        "you shouldn't see this\0",
+    ));
+    savw_scans_to_add.push(custom_asset_ids::SHORELINES_POI_SCAN);
+    assets.extend_from_slice(&create_item_scan_strg_pair(
+        custom_asset_ids::MQA_POI_SCAN,
+        custom_asset_ids::MQA_POI_STRG,
+        "Scan Visor is a Movement System.\0",
+    ));
+    savw_scans_to_add.push(custom_asset_ids::MQA_POI_SCAN);
 
     if starting_memo.is_some() {
         assets.push(build_resource(

--- a/src/custom_assets.rs
+++ b/src/custom_assets.rs
@@ -191,6 +191,7 @@ pub fn custom_assets<'r>(
     starting_memo: Option<&str>,
     pickup_hudmemos: &mut HashMap::<PickupHashKey, ResId<res_id::STRG>>,
     pickup_scans: &mut HashMap<PickupHashKey, (ResId<res_id::SCAN>, ResId<res_id::STRG>)>,
+    extra_scans: &mut HashMap<PickupHashKey, (ResId<res_id::SCAN>, ResId<res_id::STRG>)>,
     config: &PatchConfig,
 ) -> (Vec<Resource<'r>>, Vec<ResId<res_id::SCAN>>)
 {
@@ -282,6 +283,40 @@ pub fn custom_assets<'r>(
     for (level_name, level) in config.level_data.iter() {
         for (room_name, room) in level.rooms.iter() {
             let mut pickup_idx = 0;
+            let mut extra_scans_idx = 0;
+
+            if room.extra_scans.is_some() {
+                for custom_scan in room.extra_scans.as_ref().unwrap().iter() {
+                    // Get next 2 IDs //
+                    let scan_id = ResId::<res_id::SCAN>::new(custom_asset_ids::EXTRA_IDS_START.to_u32() + custom_asset_offset);
+                    custom_asset_offset = custom_asset_offset + 1;
+                    let strg_id = ResId::<res_id::STRG>::new(custom_asset_ids::EXTRA_IDS_START.to_u32() + custom_asset_offset);
+                    custom_asset_offset = custom_asset_offset + 1;
+
+                    let is_red = {
+                        if custom_scan.is_red {
+                            1
+                        } else {
+                            0
+                        }
+                    };
+
+                    assets.extend_from_slice(&create_item_scan_strg_pair_2(
+                        scan_id,
+                        strg_id,
+                        format!("{}\0", custom_scan.text).as_str(),
+                        is_red,
+                    ));
+
+                    // Map for easy lookup when patching //
+                    let key = PickupHashKey::from_location(level_name, room_name, extra_scans_idx);
+                    extra_scans.insert(key, (scan_id, strg_id));
+                    savw_scans_to_add.push(scan_id);
+
+                    extra_scans_idx = extra_scans_idx + 1;
+                }
+            }
+
             if room.pickups.is_none() { continue };
             for pickup in room.pickups.as_ref().unwrap().iter() {
                 // custom hudmemo string
@@ -398,6 +433,7 @@ pub fn collect_game_resources<'r>(
         HashMap<(u32, FourCC), structs::Resource<'r>>,
         HashMap<PickupHashKey, ResId<res_id::STRG>>,
         HashMap<PickupHashKey, (ResId<res_id::SCAN>, ResId<res_id::STRG>)>,
+        HashMap<PickupHashKey, (ResId<res_id::SCAN>, ResId<res_id::STRG>)>,
         Vec<ResId<res_id::SCAN>>,
     )
 {
@@ -437,11 +473,12 @@ pub fn collect_game_resources<'r>(
     // Maps pickup location to STRG to use
     let mut pickup_hudmemos = HashMap::<PickupHashKey, ResId<res_id::STRG>>::new();
     let mut pickup_scans = HashMap::<PickupHashKey, (ResId<res_id::SCAN>, ResId<res_id::STRG>)>::new();
+    let mut extra_scans = HashMap::<PickupHashKey, (ResId<res_id::SCAN>, ResId<res_id::STRG>)>::new();
 
     // Remove extra assets from dependency search since they won't appear     //
     // in any pak. Instead add them to the output resource pool. These assets //
     // are provided as external files checked into the repository.            //
-    let (custom_assets, savw_scans_to_add) = custom_assets(&found, starting_memo, &mut pickup_hudmemos, &mut pickup_scans, config);
+    let (custom_assets, savw_scans_to_add) = custom_assets(&found, starting_memo, &mut pickup_hudmemos, &mut pickup_scans, &mut extra_scans, config);
     for res in custom_assets {
         let key = (res.file_id, res.fourcc());
         looking_for.remove(&key);
@@ -452,7 +489,7 @@ pub fn collect_game_resources<'r>(
         panic!("error - still looking for {:?}", looking_for);
     }
 
-    (found, pickup_hudmemos, pickup_scans, savw_scans_to_add)
+    (found, pickup_hudmemos, pickup_scans, extra_scans, savw_scans_to_add)
 }
 
 fn create_custom_door_cmdl<'r>(

--- a/src/elevators.rs
+++ b/src/elevators.rs
@@ -617,7 +617,7 @@ impl SpawnRoomData
 
             let mut idx: u32 = 0;
             for room_info in rooms.iter() { // for each room in the pak
-                if room_info.name.to_lowercase() == room_name {
+                if room_info.name.to_lowercase().trim() == room_name { // trim both because "west tower " has an extra space in it
 
                     return SpawnRoomData {
                         pak_name,

--- a/src/elevators.rs
+++ b/src/elevators.rs
@@ -184,6 +184,18 @@ impl Elevator
     }
 }
 
+pub fn is_elevator(mrea: u32) -> bool {
+    for elv in Elevator::iter() {
+        if mrea == elv.elevator_data().mrea &&
+        mrea != Elevator::ArtifactTemple.elevator_data().mrea &&
+        mrea != Elevator::CraterEntryPoint.elevator_data().mrea
+        {
+            return true;
+        }
+    }
+    false
+}
+
 impl std::ops::Deref for Elevator
 {
     type Target = ElevatorData;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![recursion_limit = "128"]
+#![recursion_limit = "256"]
 
 pub use structs;
 pub use reader_writer;

--- a/src/mlvl_wrapper.rs
+++ b/src/mlvl_wrapper.rs
@@ -59,7 +59,8 @@ impl<'r, 'mlvl, 'cursor, 'list> MlvlArea<'r, 'mlvl, 'cursor, 'list>
 
     pub fn mrea(&mut self) -> &mut Mrea<'r>
     {
-        self.mrea_cursor.value().unwrap().kind.as_mrea_mut().unwrap()
+        let x = self.mrea_cursor.value().unwrap();
+        x.kind.as_mrea_mut().unwrap()
     }
 
     pub fn add_layer(&mut self, name: CStr<'r>)

--- a/src/patch_config.rs
+++ b/src/patch_config.rs
@@ -80,22 +80,31 @@ pub struct PickupConfig
     // pub desination: Option<String>,
 }
 
+#[derive(Deserialize, Debug, Default, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct ScanConfig
+{
+    pub position: [f32;3],
+    pub text: String,
+    pub is_red: bool,
+}
+
 // TODO: defaults
 #[derive(Deserialize, Debug, Default, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct RoomConfig
 {
-    // pub remove_locks: bool,
-    // pub superheated: bool,
-    // pub remove_water: bool,
-    // pub submerge: bool,
-    // pub extra_water: Vec<WaterConfig>,
-    // pub doors: Vec<String>,
-    // pub blast_shields: Vec<String>,
-    pub pickups: Vec<PickupConfig>,
-    // pub extra_pickups: Vec<PickupConfig>,
-    // pub extra_scans: Vec<ScanConfig>,
-    // pub aether_transform: Vec<AetherTransformConfig>,
+    // pub remove_locks: Option<bool>,
+    // pub superheated: Option<i8>,
+    // pub remove_water: Option<bool>,
+    // pub submerge: Option<bool>,
+    // pub extra_water: Option<Vec<WaterConfig>>,
+    // pub doors: Option<Vec<String>>,
+    // pub blast_shields: Option<Vec<String>>,
+    pub pickups: Option<Vec<PickupConfig>>,
+    // pub extra_pickups: Option<Vec<PickupConfig>>,
+    pub extra_scans: Option<Vec<ScanConfig>>,
+    // pub aether_transform: Option<Vec<AetherTransformConfig>>,
 }
 
 #[derive(Deserialize, Debug, Default, Clone)]

--- a/src/patches.rs
+++ b/src/patches.rs
@@ -2775,7 +2775,7 @@ fn patch_remove_cutscenes(
             }
 
             // ball triggers can be mean sometimes when not in the saftey of a cutscene, tone it down from 40 to 10
-            if obj.property_data.is_ball_trigger() {
+            if obj.property_data.is_ball_trigger() && room_id != 0xEF069019 {
                 let ball_trigger = obj.property_data.as_ball_trigger_mut().unwrap();
                 ball_trigger.force = 10.0;
             }

--- a/src/patches.rs
+++ b/src/patches.rs
@@ -2604,7 +2604,11 @@ fn patch_remove_cutscenes(
             // If it's a cutscene-related timer, make it take 1 frame
             if obj.property_data.is_timer() && timers_to_zero.contains(&obj_id) {
                 let timer = obj.property_data.as_timer_mut().unwrap();
-                timer.start_time = 0.1;
+                if obj_id == 0x0008024E {
+                    timer.start_time = 3.0;
+                } else {
+                    timer.start_time = 0.1;
+                }
             }
 
             // for each connection in that object

--- a/src/patches.rs
+++ b/src/patches.rs
@@ -4367,7 +4367,7 @@ fn patch_qol_minor_cutscenes(patcher: &mut PrimePatcher, version: Version) {
     );
     patcher.add_scly_patch(
         resource_info!("11_wateryhall.MREA").into(), // watery hall
-        move |ps, area| patch_remove_cutscenes(ps, area, vec![], vec![], false),
+        move |ps, area| patch_remove_cutscenes(ps, area, vec![0x0029280A, 0x002927FD], vec![], false),
     );
     patcher.add_scly_patch(
         resource_info!("18_halfpipe.MREA").into(), // crossway

--- a/src/patches.rs
+++ b/src/patches.rs
@@ -2904,6 +2904,9 @@ fn patch_remove_cutscenes(
                 !(shorelines_triggers.contains(&(&obj.instance_id & 0x00FFFFFF)))
             );
         }
+        else if room_id == 0xb4b41c48 { // keep the cinematic stuff in end cinema
+            layer.objects.as_mut_vec().retain(|obj| !obj.property_data.is_camera());
+        }
         else
         {
             layer.objects.as_mut_vec().retain(|obj|
@@ -4562,6 +4565,10 @@ fn patch_qol_minor_cutscenes(patcher: &mut PrimePatcher, version: Version) {
 }
 
 pub fn patch_qol_major_cutscenes(patcher: &mut PrimePatcher) {
+    patcher.add_scly_patch(
+        resource_info!("01_endcinema.MREA").into(), // Impact Crater Escape Cinema (cause why not)
+        move |ps, area| patch_remove_cutscenes(ps, area, vec![], vec![], true),
+    );
     // +Ghost death cutscene
     patcher.add_scly_patch(
         resource_info!("17_chozo_bowling.MREA").into(), // hall of the elders

--- a/src/patches.rs
+++ b/src/patches.rs
@@ -4415,6 +4415,7 @@ fn patch_qol_minor_cutscenes(patcher: &mut PrimePatcher, version: Version) {
             vec![
                 0x003400F5, 0x00340046, 0x0034004A, 0x003400EA, 0x0034004F, // leave chozo bowling cutscenes to avoid getting stuck
                 0x0034025C, 0x00340264, 0x00340268, 0x0034025B, // leave missile station cutsene
+                0x00340142, 0x00340378, // leave ghost death cutscene (it's major b/c reposition)
             ],
             false,
         ),
@@ -4489,6 +4490,18 @@ fn patch_qol_minor_cutscenes(patcher: &mut PrimePatcher, version: Version) {
 }
 
 pub fn patch_qol_major_cutscenes(patcher: &mut PrimePatcher) {
+    // +Ghost death cutscene
+    patcher.add_scly_patch(
+        resource_info!("17_chozo_bowling.MREA").into(), // hall of the elders
+        move |ps, area| patch_remove_cutscenes(ps, area,
+            vec![0x003400F4, 0x003400F8, 0x003400F9, 0x0034018C], // speed up release from bomb slots
+            vec![
+                0x003400F5, 0x00340046, 0x0034004A, 0x003400EA, 0x0034004F, // leave chozo bowling cutscenes to avoid getting stuck
+                0x0034025C, 0x00340264, 0x00340268, 0x0034025B, // leave missile station cutsene
+            ],
+            false,
+        ),
+    );
     patcher.add_scly_patch(
         resource_info!("01_ice_plaza.MREA").into(), // phendrana shorelines
         move |ps, area| patch_remove_cutscenes(ps, area, vec![0x00020203], vec![], false),

--- a/src/patches.rs
+++ b/src/patches.rs
@@ -131,7 +131,8 @@ fn build_artifact_temple_totem_scan_strings<R>(
     let mut artifact_locations = Vec::<(&str, PickupType)>::new();
     for (_, level) in config.level_data.iter() {
         for (room_name, room) in level.rooms.iter() {
-            for pickup in room.pickups.iter() {
+            if room.pickups.is_none() { continue };
+            for pickup in room.pickups.as_ref().unwrap().iter() {
                 let pickup_type = PickupType::from_str(&pickup.pickup_type);
                 if pickup_type.idx() >= PickupType::ArtifactOfLifegiver.idx() && pickup_type.idx() <= PickupType::ArtifactOfStrength.idx() {
                     artifact_locations.push((&room_name.as_str(), pickup_type));
@@ -1371,8 +1372,11 @@ fn fix_artifact_of_truth_requirements(
             let rooms = &config.level_data.get(World::TallonOverworld.to_json_key()).unwrap().rooms;
             if rooms.contains_key("Artifact Temple") {
                 let artifact_temple_pickups = &rooms.get("Artifact Temple").unwrap().pickups;
-                if artifact_temple_pickups.len() != 0 {
-                    _at_pickup_kind = PickupType::from_str(&artifact_temple_pickups[0].pickup_type).pickup_data().kind;
+                if artifact_temple_pickups.is_some() {
+                    let artifact_temple_pickups = artifact_temple_pickups.as_ref().unwrap();
+                    if artifact_temple_pickups.len() != 0 {
+                        _at_pickup_kind = PickupType::from_str(&artifact_temple_pickups[0].pickup_type).pickup_data().kind;
+                    }
                 }
             }
         }
@@ -1393,7 +1397,8 @@ fn fix_artifact_of_truth_requirements(
                 if _exists {break;}
                 for (_, room) in level.rooms.iter() {
                     if _exists {break;}
-                    for pickup in room.pickups.iter() {
+                    if room.pickups.is_none() { continue };
+                    for pickup in room.pickups.as_ref().unwrap().iter() {
                         let pickup = PickupType::from_str(&pickup.pickup_type);
                         if pickup.pickup_data().kind == kind {
                             _exists = true; // this artifact is placed somewhere in this world
@@ -3208,7 +3213,8 @@ fn patch_credits(
                 let mut _room_name = String::new();
                 for (_, level) in config.level_data.iter() {
                     for (room_name, room) in level.rooms.iter() {
-                        for pickup_info in room.pickups.iter() {
+                        if room.pickups.is_none() { continue };
+                        for pickup_info in room.pickups.as_ref().unwrap().iter() {
                             if PickupType::from_str(pickup_type.name()) == PickupType::from_str(&pickup_info.pickup_type) {
                                 _room_name = room_name.to_string();
                                 break;
@@ -3969,7 +3975,7 @@ fn patch_ctwk_player_gun(res: &mut structs::Resource, ctwk_config: &CtwkConfig)
         ctwk_player_gun.gun_position[2] = ctwk_player_gun.gun_position[2] + gun_position[2];
     }
 
-    // ctwk_player_gun.beams[0].normal.damage = 9999999.0;
+    ctwk_player_gun.beams[0].normal.damage = 9999999.0;
     Ok(())
 }
 
@@ -4897,7 +4903,9 @@ fn build_and_run_patches(gc_disc: &mut structs::GcDisc, config: &PatchConfig, ve
                 if level.is_some() {
                     let room = level.unwrap().rooms.get(room_info.name.trim());
                     if room.is_some() {
-                        _pickups = room.unwrap().pickups.clone();
+                        if room.unwrap().pickups.is_some() {
+                            _pickups = room.unwrap().pickups.clone().unwrap();
+                        }
                     }
                 }
                 _pickups

--- a/src/patches.rs
+++ b/src/patches.rs
@@ -2822,7 +2822,7 @@ fn patch_remove_cutscenes(
         }
 
         // remove all cutscene related objects from layer
-        if room_id == 0xf7285979 && i != 4 // the ridley cutscene is okay?
+        if room_id == 0xf7285979 && i != 4 // the ridley cutscene is okay
         {
             // special shorelines handling
             let shorelines_triggers = vec![
@@ -2843,7 +2843,8 @@ fn patch_remove_cutscenes(
                     obj.property_data.is_camera() ||
                     obj.property_data.is_camera_filter_keyframe() ||
                     obj.property_data.is_camera_blur_keyframe() ||
-                    obj.property_data.is_player_actor() || 
+                    obj.property_data.is_player_actor() ||
+                    vec![0x0018028E, 0x001802A1, 0x0018025C, 0x001800CC].contains(&(obj.instance_id&0x00FFFFFF)) || // thardus death sounds
                     (obj.property_data.is_special_function() && obj.property_data.as_special_function().unwrap().type_ == 0x18) // "show billboard"
                 )
             );
@@ -3968,6 +3969,7 @@ fn patch_ctwk_player_gun(res: &mut structs::Resource, ctwk_config: &CtwkConfig)
         ctwk_player_gun.gun_position[2] = ctwk_player_gun.gun_position[2] + gun_position[2];
     }
 
+    // ctwk_player_gun.beams[0].normal.damage = 9999999.0;
     Ok(())
 }
 

--- a/src/patches.rs
+++ b/src/patches.rs
@@ -388,12 +388,18 @@ fn patch_add_item<'r>(
     let scan_id = {
         if pickup_config.scan_text.is_some() {
             let (scan, strg) = *pickup_scans.get(&pickup_hash_key).unwrap();
-            
+            // let scan = ResId::<res_id::SCAN>::new(0x37C075A9);
+            // let strg = ResId::<res_id::STRG>::new(0x61805AFF);
+            let frme = ResId::<res_id::FRME>::new(0xDCEC3E77);
+
             let scan_dep: structs::Dependency = scan.into();
             area.add_dependencies(game_resources, new_layer_idx, iter::once(scan_dep));
 
             let strg_dep: structs::Dependency = strg.into();
             area.add_dependencies(game_resources, new_layer_idx, iter::once(strg_dep));
+
+            let frme_dep: structs::Dependency = frme.into();
+            area.add_dependencies(game_resources, new_layer_idx, iter::once(frme_dep));
             
             // TODO: should remove now obsolete vanilla scan from dependencies list
 
@@ -688,12 +694,18 @@ fn modify_pickups_in_mrea<'r>(
     let scan_id = {
         if pickup_config.scan_text.is_some() {
             let (scan, strg) = *pickup_scans.get(&pickup_hash_key).unwrap();
+            // let scan = ResId::<res_id::SCAN>::new(0x37C075A9);
+            // let strg = ResId::<res_id::STRG>::new(0x61805AFF);
+            let frme = ResId::<res_id::FRME>::new(0xDCEC3E77);
 
             let scan_dep: structs::Dependency = scan.into();
             area.add_dependencies(game_resources, new_layer_idx, iter::once(scan_dep));
 
             let strg_dep: structs::Dependency = strg.into();
             area.add_dependencies(game_resources, new_layer_idx, iter::once(strg_dep));
+
+            let frme_dep: structs::Dependency = frme.into();
+            area.add_dependencies(game_resources, new_layer_idx, iter::once(frme_dep));
             
             // TODO: should remove now obsolete vanilla scan from dependencies list
 

--- a/src/patches.rs
+++ b/src/patches.rs
@@ -805,12 +805,13 @@ fn modify_pickups_in_mrea<'r>(
     for layer in layers.iter_mut() {
         for obj in layer.objects.as_mut_vec().iter_mut() {
             if obj.property_data.is_point_of_interest() {
+                let obj_id = obj.instance_id&0x00FFFFFF;
                 let poi = obj.property_data.as_point_of_interest_mut().unwrap();
                 if f32::abs(poi.position[0] - position[0]) < 6.0 &&
                    f32::abs(poi.position[1] - position[1]) < 6.0 &&
                    f32::abs(poi.position[2] - position[2]) < 3.0 &&
-                   !EXCLUDE_POI.contains(&(obj.instance_id&0x00FFFFFF)) ||
-                   (pickup_location.location.instance_id == 0x428011c && vec![0x002803D0, 0x002803CF, 0x002803CE].contains(&(obj.instance_id&0x00FFFFFF)))  // research core scans
+                   !EXCLUDE_POI.contains(&obj_id) ||
+                   (pickup_location.location.instance_id == 0x428011c && obj_id == 0x002803CE)  // research core scan
                 {
                     poi.scan_param.scan = scan_id_out;
                 }

--- a/src/patches.rs
+++ b/src/patches.rs
@@ -4454,7 +4454,7 @@ pub fn patch_qol_major_cutscenes(patcher: &mut PrimePatcher) {
             vec![],
             vec![
                 // progress cutscene
-                // 0x00100463, 0x0010046F,
+                0x00100463, 0x0010046F,
                 // ridley intro cutscene
                 0x0010036F, 0x0010026C, 0x00100202, 0x00100207, 0x00100373, 0x001003C4, 0x001003D9, 0x001003DC, 0x001003E6, 0x001003CE, 0x0010020C, 0x0010021A, 0x001003EF, 0x001003E9, 0x0010021A, 0x00100491, 0x001003EE, 0x001003F0, 0x001003FE, 0x0010021F,
                 // crater entry/exit cutscene

--- a/src/patches.rs
+++ b/src/patches.rs
@@ -471,13 +471,17 @@ fn patch_add_item<'r>(
         cmdl: pickup_model_type.pickup_data().cmdl.clone(),
         ancs: pickup_model_type.pickup_data().ancs.clone(),
         part: pickup_model_type.pickup_data().part.clone(),
-        actor_params: pickup_type.pickup_data().actor_params.clone(),
+        actor_params: pickup_model_type.pickup_data().actor_params.clone(),
     };
 
     // Should we use non-default scan id? //
-    if scan_id.is_some() {
-        pickup.actor_params.scan_params.scan = scan_id.unwrap();
-    }
+    pickup.actor_params.scan_params.scan = {
+        if scan_id.is_some() {
+            scan_id.unwrap()
+       } else {
+            pickup_type.pickup_data().actor_params.scan_params.scan.clone()
+       }
+    };
     
     let mut pickup_obj = structs::SclyObject {
         instance_id: ps.fresh_instance_id_range.next().unwrap(),
@@ -924,13 +928,17 @@ fn update_pickup(
         cmdl: pickup_model_type.pickup_data().cmdl.clone(),
         ancs: pickup_model_type.pickup_data().ancs.clone(),
         part: pickup_model_type.pickup_data().part.clone(),
-        actor_params: pickup_type.pickup_data().actor_params.clone(),
+        actor_params: pickup_model_type.pickup_data().actor_params.clone(),
     };
 
     // Should we use non-default scan id? //
-    if scan_id.is_some() {
-        pickup.actor_params.scan_params.scan = scan_id.unwrap();
-    }
+    pickup.actor_params.scan_params.scan = {
+        if scan_id.is_some() {
+            scan_id.unwrap()
+       } else {
+            pickup_type.pickup_data().actor_params.scan_params.scan.clone()
+       }
+    };
 
     (position, pickup.actor_params.scan_params.scan)
 }

--- a/src/patches.rs
+++ b/src/patches.rs
@@ -4817,7 +4817,7 @@ fn build_and_run_patches(gc_disc: &mut structs::GcDisc, config: &PatchConfig, ve
                 
                 let level = config.level_data.get(world.to_json_key());
                 if level.is_some() {
-                    let room = level.unwrap().rooms.get(room_info.name);
+                    let room = level.unwrap().rooms.get(room_info.name.trim());
                     if room.is_some() {
                         _pickups = room.unwrap().pickups.clone();
                     }

--- a/src/patches.rs
+++ b/src/patches.rs
@@ -4051,7 +4051,9 @@ impl fmt::Display for Version
 fn patch_qol_game_breaking(
     patcher: &mut PrimePatcher,
     version: Version,
-    force_vanilla_layout: bool)
+    force_vanilla_layout: bool,
+    small_samus: bool,
+)
 {
     
     // randomizer-induced bugfixes
@@ -4067,14 +4069,16 @@ fn patch_qol_game_breaking(
         resource_info!("00_mines_savestation_b.MREA").into(),
         move |ps, area| patch_spawn_point_position(ps, area, [216.7245, 4.4046, -139.8873], false, true)
     );
-    patcher.add_scly_patch(
-        resource_info!("01_over_mainplaza.MREA").into(),
-        move |_ps, area| patch_spawn_point_position(_ps, area, [0.0, 0.0, 0.5], true, false)
-    );
-    patcher.add_scly_patch(
-        resource_info!("0_elev_lava_b.MREA").into(),
-        move |_ps, area| patch_spawn_point_position(_ps, area, [0.0, 0.0, 1.0], true, false)
-    );
+    if small_samus {
+        patcher.add_scly_patch(
+            resource_info!("01_over_mainplaza.MREA").into(),
+            move |_ps, area| patch_spawn_point_position(_ps, area, [0.0, 0.0, 0.5], true, false)
+        );
+        patcher.add_scly_patch(
+            resource_info!("0_elev_lava_b.MREA").into(),
+            move |_ps, area| patch_spawn_point_position(_ps, area, [0.0, 0.0, 0.7], true, false)
+        );
+    }
 
     if force_vanilla_layout { return; }
 
@@ -5126,7 +5130,7 @@ fn build_and_run_patches(gc_disc: &mut structs::GcDisc, config: &PatchConfig, ve
     }
 
     if config.qol_game_breaking {
-        patch_qol_game_breaking(&mut patcher, version, config.force_vanilla_layout);
+        patch_qol_game_breaking(&mut patcher, version, config.force_vanilla_layout, config.ctwk_config.player_size.clone().unwrap_or(1.0) < 0.9);
     }
 
     if config.qol_cosmetic {

--- a/src/patches.rs
+++ b/src/patches.rs
@@ -4411,7 +4411,7 @@ fn patch_qol_minor_cutscenes(patcher: &mut PrimePatcher, version: Version) {
     );
     patcher.add_scly_patch(
         resource_info!("08_ice_ridley.MREA").into(), // control tower
-        move |ps, area| patch_remove_cutscenes(ps, area, vec![0x002702DD], vec![], true),
+        move |ps, area| patch_remove_cutscenes(ps, area, vec![0x002702DD, 0x002702D5, 0x00270544, 0x002703DF], vec![], false),
     );
     patcher.add_scly_patch(
         resource_info!("13_ice_vault.MREA").into(), // research core

--- a/src/patches.rs
+++ b/src/patches.rs
@@ -2761,6 +2761,13 @@ fn patch_remove_cutscenes(
                 let actor = obj.property_data.as_actor_mut().unwrap();
                 actor.hitbox[1] = 0.4;
                 actor.position[1] = actor.position[1] - 0.8;
+            } else if obj_id == 0x0002023E { // main plaza turn crane left relay
+                // snap the crane immediately so fast players don't fall through the intangible animation
+                obj.connections.as_mut_vec().push(structs::Connection {
+                    state: structs::ConnectionState::ZERO,
+                    message: structs::ConnectionMsg::ACTIVATE,
+                    target_object_id: 0x0002001F, // platform
+                });
             }
 
             // ball triggers can be mean sometimes when not in the saftey of a cutscene, tone it down from 40 to 10
@@ -4334,8 +4341,7 @@ fn patch_qol_minor_cutscenes(patcher: &mut PrimePatcher, version: Version) {
         resource_info!("01_mines_mainplaza.MREA").into(), // main quarry
         move |ps, area| patch_remove_cutscenes(ps, area,
             vec![0x00020443], // turn the forcefield off faster
-            vec![0x00020021, 0x00020253, // play crane cutscene normally as there is no benefit to skipping it
-            ],
+            vec![],
             false,
         ),
     );
@@ -4470,10 +4476,6 @@ pub fn patch_qol_major_cutscenes(patcher: &mut PrimePatcher) {
     patcher.add_scly_patch(
         resource_info!("03_mines.MREA").into(), // elite research
         move |ps, area| patch_remove_cutscenes(ps, area, vec![0x000D01A9], vec![], true),
-    );
-    patcher.add_scly_patch(
-        resource_info!("01_mines_mainplaza.MREA").into(), // main quarry
-        move |ps, area| patch_remove_cutscenes(ps, area, vec![], vec![], false),
     );
     patcher.add_scly_patch(
         resource_info!("19_hive_totem.MREA").into(), // hive totem

--- a/src/patches.rs
+++ b/src/patches.rs
@@ -4354,10 +4354,6 @@ fn patch_qol_minor_cutscenes(patcher: &mut PrimePatcher, version: Version) {
         move |ps, area| patch_remove_cutscenes(ps, area, vec![], vec![], false),
     );
     patcher.add_scly_patch(
-        resource_info!("14_tl_base01.MREA").into(), // tower of light
-        move |ps, area| patch_remove_cutscenes(ps, area, vec![], vec![], false),
-    );
-    patcher.add_scly_patch(
         resource_info!("04_maproom_d.MREA").into(), // vault
         move |ps, area| patch_remove_cutscenes(ps, area, vec![], vec![], false),
     );

--- a/src/patches.rs
+++ b/src/patches.rs
@@ -4302,7 +4302,7 @@ fn patch_qol_minor_cutscenes(patcher: &mut PrimePatcher, version: Version) {
     );
     patcher.add_scly_patch(
         resource_info!("05_over_xray.MREA").into(), // life grove
-        move |ps, area| patch_remove_cutscenes(ps, area, vec![], vec![], true),
+        move |ps, area| patch_remove_cutscenes(ps, area, vec![], vec![0x002A00C4], false), // don't skip ghosts cutscene or ghosts will leave forever
     );
     patcher.add_scly_patch(
         resource_info!("01_mainplaza.MREA").into(), // main plaza

--- a/src/patches.rs
+++ b/src/patches.rs
@@ -853,11 +853,13 @@ fn modify_pickups_in_mrea<'r>(
             if obj.property_data.is_point_of_interest() {
                 let obj_id = obj.instance_id&0x00FFFFFF;
                 let poi = obj.property_data.as_point_of_interest_mut().unwrap();
-                if f32::abs(poi.position[0] - position[0]) < 6.0 &&
-                   f32::abs(poi.position[1] - position[1]) < 6.0 &&
-                   f32::abs(poi.position[2] - position[2]) < 3.0 &&
-                   !EXCLUDE_POI.contains(&obj_id) ||
-                   (pickup_location.location.instance_id == 0x428011c && obj_id == 0x002803CE)  // research core scan
+                if (
+                    f32::abs(poi.position[0] - position[0]) < 6.0 &&
+                    f32::abs(poi.position[1] - position[1]) < 6.0 &&
+                    f32::abs(poi.position[2] - position[2]) < 3.0 &&
+                    !EXCLUDE_POI.contains(&obj_id) &&
+                    pickup_location.location.instance_id != 0x002005EA
+                   ) || (pickup_location.location.instance_id == 0x428011c && obj_id == 0x002803CE)  // research core scan
                 {
                     poi.scan_param.scan = scan_id_out;
                 }
@@ -4908,6 +4910,28 @@ fn build_and_run_patches(gc_disc: &mut structs::GcDisc, config: &PatchConfig, ve
             move |ps, area| patch_samus_actor_size(ps, area, config.ctwk_config.player_size.clone().unwrap()),
         );
     }
+
+    // Add hard-coded POI
+    patcher.add_scly_patch(
+        resource_info!("01_ice_plaza.MREA").into(), // Phen Shorelines - Scannable in tower
+        move |ps, area| patch_add_poi(
+            ps, area,
+            game_resources,
+            custom_asset_ids::SHORELINES_POI_SCAN,
+            custom_asset_ids::SHORELINES_POI_STRG,
+            [-98.0624, -162.3933, 28.5371],
+        ),
+    );
+    patcher.add_scly_patch(
+        resource_info!("08_mines.MREA").into(), // MQA - Always scan dash from item
+        move |ps, area| patch_add_poi(
+            ps, area,
+            game_resources,
+            custom_asset_ids::MQA_POI_SCAN,
+            custom_asset_ids::MQA_POI_STRG,
+            [224.9169, 255.7093, -67.2823],
+        ),
+    );
 
     // Patch pickups
     for (pak_name, rooms) in pickup_meta::ROOM_INFO.iter() {

--- a/structs/src/lib.rs
+++ b/structs/src/lib.rs
@@ -51,6 +51,7 @@ pub mod scly_props
     pub mod timer;
     pub mod trigger;
     pub mod water;
+    pub mod waypoint;
     pub mod world_transporter;
 
     pub mod structs;
@@ -79,6 +80,7 @@ pub mod scly_props
     pub use self::timer::*;
     pub use self::trigger::*;
     pub use self::water::*;
+    pub use self::waypoint::*;
     pub use self::world_transporter::*;
 }
 
@@ -106,6 +108,8 @@ pub use scly_props::special_function::*;
 pub use scly_props::streamed_audio::*;
 pub use scly_props::timer::*;
 pub use scly_props::trigger::*;
+pub use scly_props::water::*;
+pub use scly_props::waypoint::*;
 pub use scly_props::world_transporter::*;
 
 pub use res_id::ResId;

--- a/structs/src/scly.rs
+++ b/structs/src/scly.rs
@@ -239,6 +239,7 @@ build_scly_property!(
     StreamedAudio,     is_streamed_audio,     as_streamed_audio,     as_streamed_audio_mut,
     Timer,             is_timer,              as_timer,              as_timer_mut,
     Trigger,           is_trigger,            as_trigger,            as_trigger_mut,
+    Waypoint,          is_waypoint,           as_waypoint,           as_waypoint_mut,
     Water,             is_water,              as_water,              as_water_mut,
     WorldTransporter,  is_world_transporter,  as_world_transporter,  as_world_transporter_mut,
 );

--- a/structs/src/scly_props/waypoint.rs
+++ b/structs/src/scly_props/waypoint.rs
@@ -1,0 +1,33 @@
+use auto_struct_macros::auto_struct;
+
+use reader_writer::CStr;
+use reader_writer::typenum::*;
+use reader_writer::generic_array::GenericArray;
+use crate::SclyPropertyData;
+
+#[auto_struct(Readable, Writable)]
+#[derive(Debug, Clone)]
+pub struct Waypoint<'r>
+{
+    #[auto_struct(expect = 13)]
+    prop_count: u32,
+
+    pub name: CStr<'r>,
+    pub position: GenericArray<f32, U3>,
+    pub rotation: GenericArray<f32, U3>,
+    pub active: u8,
+    pub unkown1: f32,
+    pub unkown2: f32,
+    pub unkown3: u32,
+    pub unkown4: u32,
+    pub unkown5: u32,
+    pub unkown6: u32,
+    pub unkown7: u32,
+    pub unkown8: u32,
+    pub unkown9: u32,
+}
+
+impl<'r> SclyPropertyData for Waypoint<'r>
+{
+    const OBJECT_TYPE: u8 = 0x02;
+}


### PR DESCRIPTION
# Scan Points
- Added `extraScans` to JSON interface, allowing for custom scan points to be placed anywhere.
- Added custom scan point to Phendrana Shorelines so that players can read the pickup text from outside the tower
- Added custom scan point to MQA over the pickup spawn so that players can use the either scan dash method for skipping spider even after collecting the MQA item
- Fixed issue where item scans would be pre-scanned
    - Hopefully fixed the infinite scan bug
    - Fixed scan progress not being saved to memory card
- Fixed Research Core Scans
    - Only top one previews item text
    - No longer shares scan progress %
    - All 3 scans are red as they were in vanilla again

# Minor Cutscenes
- Phendrana Shorelines - Added tower cutscene skip
- Control tower - Fixed doubled tower weirdness
- Life Grove - Removed cutscene skip so the ghosts fight doesn't break
- Main Quarry - Spawn crane platform instantly so fast players don't fall through intangible animation
- Chozo Ice Temple - Added small delay so the hands have time to sink before releasing the player
- Tower of Light - Removed cutscene skip entirely; Fast players will skip/Slow players will use to peek item
- Watery Hall - Turn on Eyeons a little faster
- Hall of the Elders - Ghost death cutscene is now a Major Cutscene (because of the reposition)

# Major Cutscenes
- Added cutscene skips for elevator platforms so that Samus can step of the elevator with the energy of a kid skipping the last 3 stairs on a staircase.
- Watch the game-end cutscene from first person. It's kinda scuffed, but it also kinda looks like Samus dies and blacks out.
- Re-added Ridley cutscene skip, but this time, boosting with IS by save station doesn't crash the game
- Leave in artifact temple cutscene because pressing start is faster than it playing out in game time
- Fixed Thardus death sounds blaring loudly until the room is reloaded

# Small Samus
- Added documentation of known softlocks
- Made small Samus spawn point adjustments unnoticeable regardless of size
- `PlayerSize` now scales final cutscene Actors

# Other
- Fixed wrong X-Ray / Thermal models being used for pickups
- Fixed handling of `West Tower `'s extra space
- Vault - Fixed bomb slots not ejecting players
- JSON `pickups` array is now optional