### PR TITLE
Switched to the new object id generator

### DIFF
--- a/src/mlvl_wrapper.rs
+++ b/src/mlvl_wrapper.rs
@@ -84,11 +84,11 @@ impl<'r, 'mlvl, 'cursor, 'list> MlvlArea<'r, 'mlvl, 'cursor, 'list>
 
     pub fn new_object_id_from_layer_name(&mut self, layer_name: &str) -> u32
     {
-        let layer_id = self.get_layer_id_from_name(layer_name) as u32;
+        let layer_id = self.get_layer_id_from_name(layer_name);
         return self.new_object_id_from_layer_id(layer_id);
     }
 
-    pub fn new_object_id_from_layer_id(&mut self, layer_id: u32) -> u32
+    pub fn new_object_id_from_layer_id(&mut self, layer_id: usize) -> u32
     {
         let mut new_obj_id: u32 = self.last_assigned_object_id;
         if new_obj_id == 0 {
@@ -109,7 +109,7 @@ impl<'r, 'mlvl, 'cursor, 'list> MlvlArea<'r, 'mlvl, 'cursor, 'list>
         new_obj_id |= (self.mrea_index as u32) << 16;
 
         // add the layer id to the object id
-        new_obj_id |= layer_id << 26;
+        new_obj_id |= (layer_id as u32) << 26;
 
         self.last_assigned_object_id = new_obj_id & 0xffffff;
 

--- a/src/patcher.rs
+++ b/src/patcher.rs
@@ -5,7 +5,6 @@ use crate::mlvl_wrapper::{MlvlArea, MlvlEditor};
 
 use std::{
     collections::{HashMap, HashSet},
-    ops::RangeFrom,
 };
 
 #[derive(Copy, Clone, Hash, Eq, PartialEq, Ord, PartialOrd, Debug)]
@@ -32,9 +31,11 @@ pub struct PrimePatcher<'r, 's>
     scly_patches: Vec<(MreaKey<'s>, Vec<Box<SclyPatch<'r, 's>>>)>,
 }
 
+#[derive(Default)]
 pub struct PatcherState
 {
-    pub fresh_instance_id_range: RangeFrom<u32>,
+    #[deprecated(note = "Please use mlvl_wrapper.MlvlArea.new_object_id_from_layer_id/name instead!")]
+    pub fresh_instance_id_range: (),
 }
 
 impl<'r, 's> PrimePatcher<'r, 's>
@@ -84,9 +85,7 @@ impl<'r, 's> PrimePatcher<'r, 's>
 
     pub fn run(&mut self, gc_disc: &mut GcDisc<'r>) -> Result<(), String>
     {
-        let mut patcher_state = PatcherState {
-            fresh_instance_id_range: 0xDEADBABE..
-        };
+        let mut patcher_state = PatcherState::default();
 
         let files_to_patch = self.file_patches.keys()
             .map(|k| *k)


### PR DESCRIPTION
PatcherState.fresh_instance_id_range is now deprecated
Custom blast shields now use memory relays instead of layers
Custom pickups now use memory relays instead of layers