### PR TITLE
Improved Gravity Chamber Stalactite grapple point patch

### DIFF
--- a/src/patches.rs
+++ b/src/patches.rs
@@ -6891,8 +6891,17 @@ fn patch_gravity_chamber_stalactite_grapple_point<'r>(_ps: &mut PatcherState, ar
     let scly = area.mrea().scly_section_mut();
     let layer = &mut scly.layers.as_mut_vec()[0];
 
-    // Remove the object that turns off the stalactites layer
-    layer.objects.as_mut_vec().retain(|obj| obj.instance_id != 3473722);
+    // Enable grapple point when detecting grapple beam
+    layer.objects.as_mut_vec().iter_mut()
+        .find(|obj| obj.instance_id & 0x00FFFFFF == 0x00350127)
+        .unwrap().connections.as_mut_vec()
+        .push(
+            structs::Connection {
+                target_object_id: 0x00350123,
+                state: structs::ConnectionState::ZERO,
+                message: structs::ConnectionMsg::ACTIVATE,
+            }
+        );
 
     Ok(())
 }


### PR DESCRIPTION
Instead of restoring the stalactite, it now reenables the grapple point via a timer that switches the scan point when it detects you have Grapple Beam in your inventory.