### PR TITLE
Several fixes concerning PAL/NTSC-J and item dots

### DIFF
--- a/src/patches.rs
+++ b/src/patches.rs
@@ -8742,6 +8742,11 @@ fn patch_dol<'r>(
                 fmr       f1, f15;
                 bl        { symbol_addr!("ComputeBoostBallMovement__10CMorphBallFRC11CFinalInputRC13CStateManagerf", version) };
 
+                // clear used registers
+                andi      r14, r14, 0;
+                andi      r15, r15, 0;
+                andi      r16, r16, 0;
+
                 // stack deinit
                 lwz       r0, 0x20(r1);
                 fmr       f1, f15;


### PR DESCRIPTION
- Spring ball didn't clear the used registers

Spring ball code didn't clear the registers I used to temporarly store pointers of needed structures which ended up being stored forever.

- Item dots are now hidden properly even on other worlds

On PAL/NTSC-J I take the address of [CMapWorldDrawParams](https://github.com/AxioDL/metaforce/blob/main/Runtime/AutoMapper/CMapWorld.hpp#L83) which contains a [IWorld](https://github.com/AxioDL/metaforce/blob/main/Runtime/World/CWorld.hpp#L26) instance at offset 0x24 which is either a [CDummyWorld](https://github.com/AxioDL/metaforce/blob/main/Runtime/World/CWorld.hpp#L55) or a [CWorld](https://github.com/AxioDL/metaforce/blob/main/Runtime/World/CWorld.hpp#L96) (check comments to see how I check this) which has the MLVL needed for [CGameState::StateForWorld](https://github.com/AxioDL/metaforce/blob/main/Runtime/CGameState.cpp#L255)(MLVL) which is corresponding to where the item dot is from.

On NTSC-U/NTSC-K [CMapWorldDrawParams](https://github.com/AxioDL/metaforce/blob/main/Runtime/AutoMapper/CMapWorld.hpp#L83) is kept in r31 which makes it easier than PAL/NTSC-J. It's used for the same reason as above.

- Fix patch door on PAL/NTSC-J version

For unknown reasons Tallon Overworld - Temple Security Station missile door was changed. This is the only noticeable change so far for doors.

- Fixed backward lower mines MQA patch on PAL/NTSC-J version

On PAL/NTSC-J the trigger was changed to a separate layer.