### PR TITLE
Remove/Revert use of custom memory relays

### DIFF
--- a/src/door_meta.rs
+++ b/src/door_meta.rs
@@ -280,18 +280,17 @@ impl DoorType {
     // only bomb and charge doors get scans because we are running out of memory
     pub fn scan(&self) -> ResId<res_id::SCAN> {
         match self {
-            // If these get uncommented we get infinite scan glitch
-            // DoorType::Boost        => custom_asset_ids::BOOST_DOOR_SCAN,
-            // DoorType::PowerBomb    => custom_asset_ids::POWER_BOMB_DOOR_SCAN,
-            // DoorType::Bomb         => custom_asset_ids::BOMB_DOOR_SCAN,
-            // DoorType::Missile      => custom_asset_ids::MISSILE_DOOR_SCAN,
-            // DoorType::Charge       => custom_asset_ids::CHARGE_DOOR_SCAN,
-            // DoorType::Super        => custom_asset_ids::SUPER_MISSILE_DOOR_SCAN,
-            // DoorType::Wavebuster   => custom_asset_ids::WAVEBUSTER_DOOR_SCAN,
-            // DoorType::Icespreader  => custom_asset_ids::ICESPREADER_DOOR_SCAN,
-            // DoorType::Flamethrower => custom_asset_ids::FLAMETHROWER_DOOR_SCAN,
-            // DoorType::Disabled     => custom_asset_ids::DISABLED_DOOR_SCAN,
-            // DoorType::Ai           => custom_asset_ids::AI_DOOR_SCAN,
+            DoorType::Boost        => custom_asset_ids::BOOST_DOOR_SCAN,
+            DoorType::PowerBomb    => custom_asset_ids::POWER_BOMB_DOOR_SCAN,
+            DoorType::Bomb         => custom_asset_ids::BOMB_DOOR_SCAN,
+            DoorType::Missile      => custom_asset_ids::MISSILE_DOOR_SCAN,
+            DoorType::Charge       => custom_asset_ids::CHARGE_DOOR_SCAN,
+            DoorType::Super        => custom_asset_ids::SUPER_MISSILE_DOOR_SCAN,
+            DoorType::Wavebuster   => custom_asset_ids::WAVEBUSTER_DOOR_SCAN,
+            DoorType::Icespreader  => custom_asset_ids::ICESPREADER_DOOR_SCAN,
+            DoorType::Flamethrower => custom_asset_ids::FLAMETHROWER_DOOR_SCAN,
+            DoorType::Disabled     => custom_asset_ids::DISABLED_DOOR_SCAN,
+            DoorType::Ai           => custom_asset_ids::AI_DOOR_SCAN,
 
             // vertical doors use the same scans as their horizontal variants //
             DoorType::VerticalBlue         =>   DoorType::Blue.scan(),
@@ -319,18 +318,17 @@ impl DoorType {
     // only bomb and charge doors get scans because we are running out of memory
     pub fn strg(&self) -> ResId<res_id::STRG> {
         match self {
-            // If these get uncommented we get infinite scan glitch
-            // DoorType::Boost        => custom_asset_ids::BOOST_DOOR_STRG,
-            // DoorType::PowerBomb    => custom_asset_ids::POWER_BOMB_DOOR_STRG,
-            // DoorType::Bomb         => custom_asset_ids::BOMB_DOOR_STRG,
-            // DoorType::Missile      => custom_asset_ids::MISSILE_DOOR_STRG,
-            // DoorType::Charge       => custom_asset_ids::CHARGE_DOOR_STRG,
-            // DoorType::Super        => custom_asset_ids::SUPER_MISSILE_DOOR_STRG,
-            // DoorType::Wavebuster   => custom_asset_ids::WAVEBUSTER_DOOR_STRG,
-            // DoorType::Icespreader  => custom_asset_ids::ICESPREADER_DOOR_STRG,
-            // DoorType::Flamethrower => custom_asset_ids::FLAMETHROWER_DOOR_STRG,
-            // DoorType::Disabled     => custom_asset_ids::DISABLED_DOOR_STRG,
-            // DoorType::Ai           => custom_asset_ids::AI_DOOR_STRG,
+            DoorType::Boost        => custom_asset_ids::BOOST_DOOR_STRG,
+            DoorType::PowerBomb    => custom_asset_ids::POWER_BOMB_DOOR_STRG,
+            DoorType::Bomb         => custom_asset_ids::BOMB_DOOR_STRG,
+            DoorType::Missile      => custom_asset_ids::MISSILE_DOOR_STRG,
+            DoorType::Charge       => custom_asset_ids::CHARGE_DOOR_STRG,
+            DoorType::Super        => custom_asset_ids::SUPER_MISSILE_DOOR_STRG,
+            DoorType::Wavebuster   => custom_asset_ids::WAVEBUSTER_DOOR_STRG,
+            DoorType::Icespreader  => custom_asset_ids::ICESPREADER_DOOR_STRG,
+            DoorType::Flamethrower => custom_asset_ids::FLAMETHROWER_DOOR_STRG,
+            DoorType::Disabled     => custom_asset_ids::DISABLED_DOOR_STRG,
+            DoorType::Ai           => custom_asset_ids::AI_DOOR_STRG,
 
             // vertical doors use the same scans as their horizontal variants //
             DoorType::VerticalBlue         =>   DoorType::Blue.strg(),

--- a/src/mlvl_wrapper.rs
+++ b/src/mlvl_wrapper.rs
@@ -1,5 +1,5 @@
 use structs::{
-    Area, AreaLayerFlags, Dependency, MemoryRelayConn, Mlvl, Mrea, Savw, SclyLayer, SclyObject, Resource,
+    Area, AreaLayerFlags, Dependency, MemoryRelayConn, Mlvl, Mrea, SclyLayer, SclyObject, Resource,
     ResourceListCursor
 };
 use reader_writer::{CStr, CStrConversionExtension, FourCC, LazyArray};
@@ -10,10 +10,9 @@ use std::collections::HashMap;
 pub struct MlvlEditor<'r>
 {
     pub mlvl: Mlvl<'r>,
-    pub savw: Savw<'r>,
 }
 
-pub struct MlvlArea<'r, 'mlvl, 'savw, 'cursor, 'list>
+pub struct MlvlArea<'r, 'mlvl, 'cursor, 'list>
 {
     pub mrea_index: usize,
     pub mrea_cursor: &'cursor mut ResourceListCursor<'r, 'list>,
@@ -21,22 +20,21 @@ pub struct MlvlArea<'r, 'mlvl, 'savw, 'cursor, 'list>
     pub layer_flags: &'mlvl mut AreaLayerFlags,
     pub layer_names: &'mlvl mut Vec<CStr<'r>>,
     pub memory_relay_conns: &'mlvl mut LazyArray<'r, MemoryRelayConn>,
-    pub persistent_memory_relays: &'savw mut LazyArray<'r, u32>,
     last_assigned_object_id: u32,
 }
 
 impl<'r> MlvlEditor<'r>
 {
-    pub fn new(mlvl: Mlvl<'r>, savw: Savw<'r>) -> MlvlEditor<'r>
+    pub fn new(mlvl: Mlvl<'r>) -> MlvlEditor<'r>
     {
-        MlvlEditor { mlvl, savw }
+        MlvlEditor { mlvl }
     }
 
     pub fn get_area<'s, 'cursor, 'list: 'cursor>(
         &'s mut self,
         mrea_cursor: &'cursor mut ResourceListCursor<'r, 'list>
     )
-        -> MlvlArea<'r, 's, 's, 'cursor, 'list>
+        -> MlvlArea<'r, 's, 'cursor, 'list>
     {
         assert_eq!(mrea_cursor.peek().unwrap().fourcc(), b"MREA".into());
         let file_id = mrea_cursor.peek().unwrap().file_id;
@@ -51,13 +49,12 @@ impl<'r> MlvlEditor<'r>
             layer_flags: self.mlvl.area_layer_flags.as_mut_vec().get_mut(i).unwrap(),
             layer_names: self.mlvl.area_layer_names.mut_names_for_area(i).unwrap(),
             memory_relay_conns: &mut self.mlvl.memory_relay_conns,
-            persistent_memory_relays: &mut self.savw.memory_relay_array,
             last_assigned_object_id: 0xefff,
         }
     }
 }
 
-impl<'r, 'mlvl, 'savw, 'cursor, 'list> MlvlArea<'r, 'mlvl, 'savw, 'cursor, 'list>
+impl<'r, 'mlvl, 'cursor, 'list> MlvlArea<'r, 'mlvl, 'cursor, 'list>
 {
     pub fn mrea_file_id(&mut self) -> u32
     {
@@ -160,12 +157,12 @@ impl<'r, 'mlvl, 'savw, 'cursor, 'list> MlvlArea<'r, 'mlvl, 'savw, 'cursor, 'list
             panic!("[add_memory_relay] mem_relay is not a memory relay object! (ID : {:X})", mem_relay.instance_id);
         }
 
-        if self.persistent_memory_relays.as_mut_vec().len() >= 511
-        {
-            panic!("Ran out of memory relays!");
-        }
+        // if self.persistent_memory_relays.as_mut_vec().len() >= 511
+        // {
+        //     panic!("Ran out of memory relays!");
+        // }
 
-        self.persistent_memory_relays.as_mut_vec().push(mem_relay_id);
+        // self.persistent_memory_relays.as_mut_vec().push(mem_relay_id);
 
         let active = mem_relay.property_data.as_memory_relay().unwrap().active;
 

--- a/src/mlvl_wrapper.rs
+++ b/src/mlvl_wrapper.rs
@@ -189,6 +189,11 @@ impl<'r, 'mlvl, 'cursor, 'list> MlvlArea<'r, 'mlvl, 'cursor, 'list>
 
     pub fn add_layer(&mut self, name: CStr<'r>)
     {
+        if self.layer_flags.layer_count >= 64
+        {
+            panic!("Room 0x{:X} ran out of usable layers!", self.mlvl_area.mrea.to_u32());
+        }
+
         // Mark this layer as active
         self.layer_flags.flags |= 1 << self.layer_flags.layer_count;
         self.layer_flags.layer_count += 1;

--- a/src/patches.rs
+++ b/src/patches.rs
@@ -1647,7 +1647,7 @@ fn patch_add_item<'r>(
             area.new_object_id_from_layer_id(new_layer_idx),
         ];
     }
-    let special_function_id = area.new_object_id_from_layer_name(new_layer_idx);
+    let special_function_id = area.new_object_id_from_layer_id(new_layer_idx);
     let four_ids = [
         area.new_object_id_from_layer_id(new_layer_idx),
         area.new_object_id_from_layer_id(new_layer_idx),
@@ -2968,8 +2968,7 @@ fn modify_pickups_in_mrea<'r>(
     let mut timer_id = 0;
     let mut trigger_id = 0;
     let mut floaty_contraption_id = [0, 0, 0, 0];
-    let mut poi_id = 0;
-    let mut memory_relay_id = 0;
+    let poi_id = area.new_object_id_from_layer_name("Default");
 
     let pickup_kind = pickup_type.kind();
     if pickup_kind >= 29 && pickup_kind <= 40 {
@@ -2991,30 +2990,6 @@ fn modify_pickups_in_mrea<'r>(
             area.new_object_id_from_layer_name("Default"),
             area.new_object_id_from_layer_name("Default"),
         ];
-    }
-
-    if shuffle_position || *pickup_config.jumbo_scan.as_ref().unwrap_or(&false) {
-        poi_id = area.new_object_id_from_layer_name("Default");
-        memory_relay_id = area.new_object_id_from_layer_name("Default");
-
-        let memory_relay = structs::SclyObject {
-            instance_id: memory_relay_id,
-            property_data: structs::SclyProperty::MemoryRelay(
-                Box::new(structs::MemoryRelay {
-                    name: b"MemoryRelay - remove poi\0".as_cstr(),
-                    unknown: 0,
-                    active: 0,
-                })
-            ).into(),
-            connections: vec![
-                structs::Connection {
-                    state: structs::ConnectionState::ACTIVE,
-                    message: structs::ConnectionMsg::DEACTIVATE,
-                    target_object_id: poi_id,
-                }
-            ].into(),
-        };
-        area.add_memory_relay(memory_relay);
     }
 
     let four_ids = [
@@ -3323,22 +3298,8 @@ fn modify_pickups_in_mrea<'r>(
         additional_connections.push(
             structs::Connection {
                 state: structs::ConnectionState::ARRIVED,
-                message: structs::ConnectionMsg::ACTIVATE,
-                target_object_id: memory_relay_id,
-            }
-        );
-        additional_connections.push(
-            structs::Connection {
-                state: structs::ConnectionState::ARRIVED,
                 message: structs::ConnectionMsg::DECREMENT,
                 target_object_id: poi_id,
-            }
-        );
-        relay.connections.as_mut_vec().push(
-            structs::Connection {
-                state: structs::ConnectionState::ZERO,
-                message: structs::ConnectionMsg::ACTIVATE,
-                target_object_id: memory_relay_id,
             }
         );
         relay.connections.as_mut_vec().push(

--- a/src/patches.rs
+++ b/src/patches.rs
@@ -1279,14 +1279,9 @@ fn patch_add_item<'r>(
         pickup_model_data.actor_params.thermal_cskr = ResId::invalid();
     }
 
-    let new_layer_idx = if area.layer_flags.layer_count < 60 {
-        let name = CString::new(format!(
-            "Randomizer - Pickup ({:?})", pickup_model_data.name)).unwrap();
+    let name = CString::new(format!("Randomizer - Pickup ({:?})", pickup_model_data.name)).unwrap();
         area.add_layer(Cow::Owned(name));
-        area.layer_flags.layer_count as usize - 1
-    } else {
-        0
-    };
+    let new_layer_idx = area.layer_flags.layer_count as usize - 1;
 
     // Add hudmemo string as dependency to room //
     let hudmemo_strg: ResId<res_id::STRG> = {

--- a/src/patches.rs
+++ b/src/patches.rs
@@ -3295,36 +3295,7 @@ fn modify_pickups_in_mrea<'r>(
         });
     }*/
 
-    let position: [f32; 3];
-    let scan_id_out: ResId<res_id::SCAN>;
-    {
-        if pickup_config.destination.is_some() {
-            additional_connections.extend_from_slice(
-                &world_teleporter_connections
-            );
-        }
-
-        let pickup_obj = layers[pickup_location.location.layer as usize].objects.iter_mut()
-        .find(|obj| obj.instance_id == pickup_location.location.instance_id)
-        .unwrap();
-
-        (position, scan_id_out) = update_pickup(pickup_obj, pickup_type, pickup_model_data, pickup_config, scan_id, position_override);
-
-        if additional_connections.len() > 0 {
-            pickup_obj.connections.as_mut_vec().extend_from_slice(&additional_connections);
-        }
-    }
-
     if pickup_type == PickupType::FloatyJump {
-        place_floaty_contraption(
-            layers[0].objects.as_mut_vec(),
-            floaty_contraption_id[0],
-            floaty_contraption_id[1],
-            floaty_contraption_id[2],
-            floaty_contraption_id[3],
-            position.clone().into(),
-        );
-
         additional_connections.push(
             structs::Connection {
                 state: structs::ConnectionState::ARRIVED,
@@ -3335,25 +3306,6 @@ fn modify_pickups_in_mrea<'r>(
     }
 
     if jumbo_poi {
-        layers[jumbo_poi_layer_idx].objects.as_mut_vec().push(
-            structs::SclyObject {
-                instance_id: jumbo_poi_id,
-                connections: vec![].into(),
-                property_data: structs::SclyProperty::PointOfInterest(
-                    Box::new(structs::PointOfInterest {
-                        name: b"mypoi\0".as_cstr(),
-                        position: position.clone().into(),
-                        rotation: [0.0, 0.0, 0.0].into(),
-                        active: 1,
-                        scan_param: structs::scly_structs::ScannableParameters {
-                            scan: scan_id,
-                        },
-                        point_size: 500.0, // makes it jumbo!
-                    })
-                ),
-            }
-        );
-
         layers[0].objects.as_mut_vec().push(
             structs::SclyObject {
                 instance_id: jumbo_poi_special_function_id,
@@ -3404,6 +3356,58 @@ fn modify_pickups_in_mrea<'r>(
                 .unwrap();
             trigger.active = 1;
         }
+    }
+
+    let position: [f32; 3];
+    let scan_id_out: ResId<res_id::SCAN>;
+    {
+        if pickup_config.destination.is_some() {
+            additional_connections.extend_from_slice(
+                &world_teleporter_connections
+            );
+        }
+
+        let pickup_obj = layers[pickup_location.location.layer as usize].objects.iter_mut()
+        .find(|obj| obj.instance_id == pickup_location.location.instance_id)
+        .unwrap();
+
+        (position, scan_id_out) = update_pickup(pickup_obj, pickup_type, pickup_model_data, pickup_config, scan_id, position_override);
+
+        if additional_connections.len() > 0 {
+            pickup_obj.connections.as_mut_vec().extend_from_slice(&additional_connections);
+        }
+    }
+
+    if pickup_type == PickupType::FloatyJump {
+        place_floaty_contraption(
+            layers[0].objects.as_mut_vec(),
+            floaty_contraption_id[0],
+            floaty_contraption_id[1],
+            floaty_contraption_id[2],
+            floaty_contraption_id[3],
+            position.clone().into(),
+        );
+    }
+
+    if jumbo_poi {
+        layers[jumbo_poi_layer_idx].objects.as_mut_vec().push(
+            structs::SclyObject {
+                instance_id: jumbo_poi_id,
+                connections: vec![].into(),
+                property_data: structs::SclyProperty::PointOfInterest(
+                    Box::new(structs::PointOfInterest {
+                        name: b"mypoi\0".as_cstr(),
+                        position: position.clone().into(),
+                        rotation: [0.0, 0.0, 0.0].into(),
+                        active: 1,
+                        scan_param: structs::scly_structs::ScannableParameters {
+                            scan: scan_id,
+                        },
+                        point_size: 500.0, // makes it jumbo!
+                    })
+                ),
+            }
+        );
     }
 
     layers[0].objects.as_mut_vec().push(relay);

--- a/src/patches.rs
+++ b/src/patches.rs
@@ -279,7 +279,7 @@ fn patch_save_banner_txtr(res: &mut structs::Resource)
 
 fn patch_tournament_winners<'r>(
     _ps: &mut PatcherState,
-    area: &mut mlvl_wrapper::MlvlArea<'r, '_, '_, '_, '_>,
+    area: &mut mlvl_wrapper::MlvlArea<'r, '_, '_, '_>,
     game_resources: &HashMap<(u32, FourCC), structs::Resource<'r>>,
 )
 -> Result<(), String>
@@ -469,7 +469,7 @@ fn patch_map_door_icon(
 
 fn patch_remove_blast_shield<'r>(
     _ps: &mut PatcherState,
-    area: &mut mlvl_wrapper::MlvlArea<'r, '_, '_, '_, '_>,
+    area: &mut mlvl_wrapper::MlvlArea<'r, '_, '_, '_>,
     dock_num: u32,
 ) -> Result<(), String> {
     let mut dock_position: GenericArray<f32, U3> = [0.0, 0.0, 0.0].into();
@@ -522,7 +522,7 @@ fn patch_remove_blast_shield<'r>(
 
 fn patch_door<'r>(
     _ps: &mut PatcherState,
-    area: &mut mlvl_wrapper::MlvlArea<'r, '_, '_, '_, '_>,
+    area: &mut mlvl_wrapper::MlvlArea<'r, '_, '_, '_>,
     door_loc: ModifiableDoorLocation,
     door_type: Option<DoorType>,
     blast_shield_type: Option<BlastShieldType>,
@@ -1207,7 +1207,7 @@ fn patch_door<'r>(
 // TODO: factor out shared code with modify_pickups_in_mrea
 fn patch_add_item<'r>(
     _ps: &mut PatcherState,
-    area: &mut mlvl_wrapper::MlvlArea<'r, '_, '_, '_, '_>,
+    area: &mut mlvl_wrapper::MlvlArea<'r, '_, '_, '_>,
     pickup_idx: usize,
     pickup_config: &PickupConfig,
     game_resources: &HashMap<(u32, FourCC), structs::Resource<'r>>,
@@ -1783,7 +1783,7 @@ fn patch_add_item<'r>(
 }
 
 fn add_world_teleporter<'r>(
-    area: &mut mlvl_wrapper::MlvlArea<'r, '_, '_, '_, '_>,
+    area: &mut mlvl_wrapper::MlvlArea<'r, '_, '_, '_>,
     destination: &str,
     version: Version,
 ) -> Vec<structs::Connection>
@@ -1926,7 +1926,7 @@ fn is_area_damage_special_function<'r>(obj: &structs::SclyObject<'r>)
 
 fn patch_deheat_room<'r>(
     _ps: &mut PatcherState,
-    area: &mut mlvl_wrapper::MlvlArea<'r, '_, '_, '_, '_>,
+    area: &mut mlvl_wrapper::MlvlArea<'r, '_, '_, '_>,
 )
 -> Result<(), String>
 {
@@ -1942,7 +1942,7 @@ fn patch_deheat_room<'r>(
 
 fn patch_superheated_room<'r>(
     _ps: &mut PatcherState,
-    area: &mut mlvl_wrapper::MlvlArea<'r, '_, '_, '_, '_>,
+    area: &mut mlvl_wrapper::MlvlArea<'r, '_, '_, '_>,
     heat_damage_per_sec: f32,
 )
 -> Result<(), String>
@@ -1998,7 +1998,7 @@ fn is_underwater_sound<'r>(obj: &structs::SclyObject<'r>) -> bool {
 
 fn patch_remove_water<'r>(
     _ps: &mut PatcherState,
-    area: &mut mlvl_wrapper::MlvlArea<'r, '_, '_, '_, '_>,
+    area: &mut mlvl_wrapper::MlvlArea<'r, '_, '_, '_>,
 )
 -> Result<(), String>
 {
@@ -2389,7 +2389,7 @@ impl WaterType
 
 fn patch_submerge_room<'r>(
     _ps: &mut PatcherState,
-    area: &mut mlvl_wrapper::MlvlArea<'r, '_, '_, '_, '_>,
+    area: &mut mlvl_wrapper::MlvlArea<'r, '_, '_, '_>,
     resources: &HashMap<(u32, FourCC), structs::Resource<'r>>,
 )
 -> Result<(), String>
@@ -2428,7 +2428,7 @@ fn patch_submerge_room<'r>(
 
 fn patch_add_liquid<'r>(
     _ps: &mut PatcherState,
-    area: &mut mlvl_wrapper::MlvlArea<'r, '_, '_, '_, '_>,
+    area: &mut mlvl_wrapper::MlvlArea<'r, '_, '_, '_>,
     water_config: &WaterConfig,
     resources: &HashMap<(u32, FourCC), structs::Resource<'r>>,
 )
@@ -2465,7 +2465,7 @@ fn patch_add_liquid<'r>(
 
 fn patch_remove_tangle_weed_scan_point<'r>(
     _ps: &mut PatcherState,
-    area: &mut mlvl_wrapper::MlvlArea<'r, '_, '_, '_, '_>,
+    area: &mut mlvl_wrapper::MlvlArea<'r, '_, '_, '_>,
     tangle_weed_ids: Vec<u32>,
 ) -> Result<(), String>
 {
@@ -2487,7 +2487,7 @@ fn patch_remove_tangle_weed_scan_point<'r>(
 
 fn patch_add_poi<'r>(
     _ps: &mut PatcherState,
-    area: &mut mlvl_wrapper::MlvlArea<'r, '_, '_, '_, '_>,
+    area: &mut mlvl_wrapper::MlvlArea<'r, '_, '_, '_>,
     game_resources: &HashMap<(u32, FourCC), structs::Resource<'r>>,
     scan_id: ResId<res_id::SCAN>,
     strg_id: ResId<res_id::STRG>,
@@ -2532,7 +2532,7 @@ fn patch_add_poi<'r>(
 
 fn patch_add_scan_actor<'r>(
     _ps: &mut PatcherState,
-    area: &mut mlvl_wrapper::MlvlArea<'r, '_, '_, '_, '_>,
+    area: &mut mlvl_wrapper::MlvlArea<'r, '_, '_, '_>,
     game_resources: &HashMap<(u32, FourCC), structs::Resource<'r>>,
     position: [f32;3],
     rotation: f32,
@@ -2659,7 +2659,7 @@ where R: Rng
 }
 
 fn get_shuffled_position<'r, R>(
-    area: &mut mlvl_wrapper::MlvlArea<'r, '_, '_, '_, '_>,
+    area: &mut mlvl_wrapper::MlvlArea<'r, '_, '_, '_>,
     rng: &mut R,
 )
 -> [f32; 3]
@@ -2795,7 +2795,7 @@ fn add_pickups_to_mapa<'r>(
 
 fn modify_pickups_in_mrea<'r>(
     _ps: &mut PatcherState,
-    area: &mut mlvl_wrapper::MlvlArea<'r, '_, '_, '_, '_>,
+    area: &mut mlvl_wrapper::MlvlArea<'r, '_, '_, '_>,
     _pickup_idx: usize,
     pickup_config: &PickupConfig,
     pickup_location: pickup_meta::PickupLocation,
@@ -3689,7 +3689,7 @@ fn rotate(mut coordinate: [f32; 3], mut rotation: [f32; 3], center: [f32; 3])
 
 fn patch_samus_actor_size<'r>(
     _ps: &mut PatcherState,
-    area: &mut mlvl_wrapper::MlvlArea<'r, '_, '_, '_, '_>,
+    area: &mut mlvl_wrapper::MlvlArea<'r, '_, '_, '_>,
     player_size: f32,
 ) -> Result<(), String>
 {
@@ -3745,7 +3745,7 @@ fn patch_samus_actor_size<'r>(
 
 fn patch_elevator_actor_size<'r>(
     _ps: &mut PatcherState,
-    area: &mut mlvl_wrapper::MlvlArea<'r, '_, '_, '_, '_>,
+    area: &mut mlvl_wrapper::MlvlArea<'r, '_, '_, '_>,
     player_size: f32,
 ) -> Result<(), String>
 {
@@ -4089,7 +4089,7 @@ fn patch_post_pq_frigate(
 
 fn patch_add_platform<'r>(
     _ps: &mut PatcherState,
-    area: &mut mlvl_wrapper::MlvlArea<'r, '_, '_, '_, '_>,
+    area: &mut mlvl_wrapper::MlvlArea<'r, '_, '_, '_>,
     game_resources: &HashMap<(u32, FourCC), structs::Resource<'r>>,
     position: [f32;3],
     rotation: [f32;3],
@@ -4220,7 +4220,7 @@ fn patch_add_platform<'r>(
 }
 
 fn add_block<'r>(
-    area: &mut mlvl_wrapper::MlvlArea<'r, '_, '_, '_, '_>,
+    area: &mut mlvl_wrapper::MlvlArea<'r, '_, '_, '_>,
     position: [f32;3],
     scale: [f32;3],
     texture: GenericTexture,
@@ -4313,7 +4313,7 @@ fn add_block<'r>(
 
 fn patch_add_block<'r>(
     _ps: &mut PatcherState,
-    area: &mut mlvl_wrapper::MlvlArea<'r, '_, '_, '_, '_>,
+    area: &mut mlvl_wrapper::MlvlArea<'r, '_, '_, '_>,
     game_resources: &HashMap<(u32, FourCC), structs::Resource<'r>>,
     position: [f32;3],
     scale: [f32;3],
@@ -4357,7 +4357,7 @@ fn local_to_global_tranform(
 }
 
 fn derrive_bounding_box_measurements<'r>(
-    area: &mut mlvl_wrapper::MlvlArea<'r, '_, '_, '_, '_>,
+    area: &mut mlvl_wrapper::MlvlArea<'r, '_, '_, '_>,
 ) -> ([f32;3], [f32;3], [f32;3], [f32;3])
 {
     let area_transform: [f32;12] = area.mlvl_area.area_transform.into();
@@ -4392,7 +4392,7 @@ fn derrive_bounding_box_measurements<'r>(
 
 fn patch_visible_aether_boundaries<'r>(
     _ps: &mut PatcherState,
-    area: &mut mlvl_wrapper::MlvlArea<'r, '_, '_, '_, '_>,
+    area: &mut mlvl_wrapper::MlvlArea<'r, '_, '_, '_>,
     game_resources: &HashMap<(u32, FourCC), structs::Resource<'r>>,
 )
 -> Result<(), String>
@@ -4474,7 +4474,7 @@ fn patch_visible_aether_boundaries<'r>(
 
 fn patch_add_escape_sequence<'r>(
     _ps: &mut PatcherState,
-    area: &mut mlvl_wrapper::MlvlArea<'r, '_, '_, '_, '_>,
+    area: &mut mlvl_wrapper::MlvlArea<'r, '_, '_, '_>,
     // mut time_s: f32,
     start_trigger_pos: [f32;3],
     start_trigger_scale: [f32;3],
@@ -4607,7 +4607,7 @@ fn patch_add_escape_sequence<'r>(
 
 fn patch_lock_on_point<'r>(
     _ps: &mut PatcherState,
-    area: &mut mlvl_wrapper::MlvlArea<'r, '_, '_, '_, '_>,
+    area: &mut mlvl_wrapper::MlvlArea<'r, '_, '_, '_>,
     game_resources: &HashMap<(u32, FourCC), structs::Resource<'r>>,
     position: [f32;3],
     is_grapple: bool,
@@ -4912,7 +4912,7 @@ fn patch_lock_on_point<'r>(
 
 fn patch_ambient_lighting<'r>(
     _ps: &mut PatcherState,
-    area: &mut mlvl_wrapper::MlvlArea<'r, '_, '_, '_, '_>,
+    area: &mut mlvl_wrapper::MlvlArea<'r, '_, '_, '_>,
     scale: f32,
 ) -> Result<(), String>
 {
@@ -4930,7 +4930,7 @@ fn patch_ambient_lighting<'r>(
 
 // fn patch_add_orange_light<'r>(
 //     ps: &mut PatcherState,
-//     area: &mut mlvl_wrapper::MlvlArea<'r, '_, '_, '_, '_>,
+//     area: &mut mlvl_wrapper::MlvlArea<'r, '_, '_, '_>,
 //     game_resources: &HashMap<(u32, FourCC), structs::Resource<'r>>,
 //     position: [f32;3],
 //     scale: [f32;3],
@@ -6089,7 +6089,7 @@ fn patch_arboretum_invisible_wall(
 fn patch_cutscene_force_phazon_suit<'r>
 (
     _ps: &mut PatcherState,
-    area: &mut mlvl_wrapper::MlvlArea<'r, '_, '_, '_, '_>,
+    area: &mut mlvl_wrapper::MlvlArea<'r, '_, '_, '_>,
 )
 -> Result<(), String>
 {
@@ -6111,7 +6111,7 @@ fn patch_cutscene_force_phazon_suit<'r>
 fn patch_remove_otrs<'r>
 (
     _ps: &mut PatcherState,
-    area: &mut mlvl_wrapper::MlvlArea<'r, '_, '_, '_, '_>,
+    area: &mut mlvl_wrapper::MlvlArea<'r, '_, '_, '_>,
     otrs: &'static [ObjectsToRemove],
     remove: bool,
 )
@@ -6130,7 +6130,7 @@ fn patch_remove_otrs<'r>
 fn patch_remove_ids<'r>
 (
     _ps: &mut PatcherState,
-    area: &mut mlvl_wrapper::MlvlArea<'r, '_, '_, '_, '_>,
+    area: &mut mlvl_wrapper::MlvlArea<'r, '_, '_, '_>,
     remove_ids: Vec<u32>,
 )
 -> Result<(), String>
@@ -6146,7 +6146,7 @@ fn patch_remove_ids<'r>
 fn patch_remove_doors<'r>
 (
     _ps: &mut PatcherState,
-    area: &mut mlvl_wrapper::MlvlArea<'r, '_, '_, '_, '_>,
+    area: &mut mlvl_wrapper::MlvlArea<'r, '_, '_, '_>,
 )
 -> Result<(), String>
 {
@@ -6164,7 +6164,7 @@ fn patch_remove_doors<'r>
 
 fn patch_transform_bounding_box<'r>(
     _ps: &mut PatcherState,
-    area: &mut mlvl_wrapper::MlvlArea<'r, '_, '_, '_, '_>,
+    area: &mut mlvl_wrapper::MlvlArea<'r, '_, '_, '_>,
     offset: [f32;3],
     scale: [f32;3],
 )
@@ -6189,7 +6189,7 @@ fn patch_transform_bounding_box<'r>(
 
 fn patch_spawn_point_position<'r>(
     _ps: &mut PatcherState,
-    area: &mut mlvl_wrapper::MlvlArea<'r, '_, '_, '_, '_>,
+    area: &mut mlvl_wrapper::MlvlArea<'r, '_, '_, '_>,
     new_position: [f32; 3],
     relative_position: bool,
     force_default: bool,
@@ -7260,7 +7260,7 @@ fn patch_heat_damage_per_sec<'a>(patcher: &mut PrimePatcher<'_, 'a>, heat_damage
 
 fn patch_save_station_for_warp_to_start<'r>(
     _ps: &mut PatcherState,
-    area: &mut mlvl_wrapper::MlvlArea<'r, '_, '_, '_, '_>,
+    area: &mut mlvl_wrapper::MlvlArea<'r, '_, '_, '_>,
     game_resources: &HashMap<(u32, FourCC), structs::Resource<'r>>,
     spawn_room: SpawnRoomData,
     version: Version,
@@ -7692,7 +7692,7 @@ fn patch_completion_screen(
 
 fn patch_starting_pickups<'r>(
     _ps: &mut PatcherState,
-    area: &mut mlvl_wrapper::MlvlArea<'r, '_, '_, '_, '_>,
+    area: &mut mlvl_wrapper::MlvlArea<'r, '_, '_, '_>,
     starting_items: &StartingItems,
     show_starting_memo: bool,
     game_resources: &HashMap<(u32, FourCC), structs::Resource<'r>>,
@@ -9311,7 +9311,7 @@ fn patch_ctwk_ball(res: &mut structs::Resource, ctwk_config: &CtwkConfig)
 
 fn patch_subchamber_five_nintendont_fix<'r>(
     _ps: &mut PatcherState,
-    area: &mut mlvl_wrapper::MlvlArea<'r, '_, '_, '_, '_>,
+    area: &mut mlvl_wrapper::MlvlArea<'r, '_, '_, '_>,
 )
 -> Result<(), String>
 {
@@ -9355,7 +9355,7 @@ fn patch_subchamber_five_nintendont_fix<'r>(
 
 fn patch_final_boss_permadeath<'r>(
     _ps: &mut PatcherState,
-    area: &mut mlvl_wrapper::MlvlArea<'r, '_, '_, '_, '_>,
+    area: &mut mlvl_wrapper::MlvlArea<'r, '_, '_, '_>,
     game_resources: &HashMap<(u32, FourCC), structs::Resource<'r>>,
 )
 -> Result<(), String>
@@ -9928,7 +9928,7 @@ fn patch_ctwk_gui_colors(res: &mut structs::Resource, ctwk_config: &CtwkConfig)
 
 fn patch_move_item_loss_scan<'r>(
     _ps: &mut PatcherState,
-    area: &mut mlvl_wrapper::MlvlArea<'r, '_, '_, '_, '_>,
+    area: &mut mlvl_wrapper::MlvlArea<'r, '_, '_, '_>,
 )
 -> Result<(), String>
 {
@@ -9950,7 +9950,7 @@ fn patch_move_item_loss_scan<'r>(
 
 // fn patch_remove_visor_changer<'r>(
 //     _ps: &mut PatcherState,
-//     area: &mut mlvl_wrapper::MlvlArea<'r, '_, '_, '_, '_>,
+//     area: &mut mlvl_wrapper::MlvlArea<'r, '_, '_, '_>,
 // )
 // -> Result<(), String>
 // {
@@ -9989,7 +9989,7 @@ fn is_blast_shield_poi<'r>(obj: &structs::SclyObject<'r>) -> bool {
 
 fn patch_remove_blast_shields<'r>(
     _ps: &mut PatcherState,
-    area: &mut mlvl_wrapper::MlvlArea<'r, '_, '_, '_, '_>,
+    area: &mut mlvl_wrapper::MlvlArea<'r, '_, '_, '_>,
 )
 -> Result<(), String>
 {
@@ -10005,7 +10005,7 @@ fn patch_remove_blast_shields<'r>(
 
 fn patch_remove_control_disabler<'r>(
     _ps: &mut PatcherState,
-    area: &mut mlvl_wrapper::MlvlArea<'r, '_, '_, '_, '_>,
+    area: &mut mlvl_wrapper::MlvlArea<'r, '_, '_, '_>,
 )
 -> Result<(), String>
 {
@@ -10030,7 +10030,7 @@ fn patch_remove_control_disabler<'r>(
 
 fn patch_add_camera_hint<'r>(
     _ps: &mut PatcherState,
-    area: &mut mlvl_wrapper::MlvlArea<'r, '_, '_, '_, '_>,
+    area: &mut mlvl_wrapper::MlvlArea<'r, '_, '_, '_>,
     trigger_pos: [f32;3],
     trigger_scale: [f32;3],
     camera_pos: [f32;3],
@@ -10231,7 +10231,7 @@ fn add_camera_hint<'r>(
 
 fn patch_add_dock_teleport<'r>(
     _ps: &mut PatcherState,
-    area: &mut mlvl_wrapper::MlvlArea<'r, '_, '_, '_, '_>,
+    area: &mut mlvl_wrapper::MlvlArea<'r, '_, '_, '_>,
     source_position: [f32;3],
     source_scale: [f32;3],
     destination_dock_num: u32,
@@ -10556,7 +10556,7 @@ fn patch_add_dock_teleport<'r>(
 
 fn patch_modify_dock<'r>(
     _ps: &mut PatcherState,
-    area: &mut mlvl_wrapper::MlvlArea<'r, '_, '_, '_, '_>,
+    area: &mut mlvl_wrapper::MlvlArea<'r, '_, '_, '_>,
     game_resources: &HashMap<(u32, FourCC), structs::Resource<'r>>,
     scan_id: ResId<res_id::SCAN>,
     strg_id: ResId<res_id::STRG>,
@@ -10766,7 +10766,7 @@ fn patch_modify_dock<'r>(
 
 fn patch_exo_scale<'r>(
     _ps: &mut PatcherState,
-    area: &mut mlvl_wrapper::MlvlArea<'r, '_, '_, '_, '_>,
+    area: &mut mlvl_wrapper::MlvlArea<'r, '_, '_, '_>,
     scale: f32,
 )
 -> Result<(), String>
@@ -10797,7 +10797,7 @@ fn patch_exo_scale<'r>(
 
 fn patch_ridley_scale<'r>(
     _ps: &mut PatcherState,
-    area: &mut mlvl_wrapper::MlvlArea<'r, '_, '_, '_, '_>,
+    area: &mut mlvl_wrapper::MlvlArea<'r, '_, '_, '_>,
     version: Version,
     scale: f32,
 )
@@ -10841,7 +10841,7 @@ fn patch_ridley_scale<'r>(
 
 fn patch_omega_pirate_scale<'r>(
     _ps: &mut PatcherState,
-    area: &mut mlvl_wrapper::MlvlArea<'r, '_, '_, '_, '_>,
+    area: &mut mlvl_wrapper::MlvlArea<'r, '_, '_, '_>,
     scale: f32,
 )
 -> Result<(), String>
@@ -10898,7 +10898,7 @@ fn patch_omega_pirate_scale<'r>(
 
 fn patch_elite_pirate_scale<'r>(
     _ps: &mut PatcherState,
-    area: &mut mlvl_wrapper::MlvlArea<'r, '_, '_, '_, '_>,
+    area: &mut mlvl_wrapper::MlvlArea<'r, '_, '_, '_>,
     scale: f32,
 )
 -> Result<(), String>
@@ -10935,7 +10935,7 @@ fn patch_elite_pirate_scale<'r>(
 
 fn patch_sheegoth_scale<'r>(
     _ps: &mut PatcherState,
-    area: &mut mlvl_wrapper::MlvlArea<'r, '_, '_, '_, '_>,
+    area: &mut mlvl_wrapper::MlvlArea<'r, '_, '_, '_>,
     scale: f32,
 )
 -> Result<(), String>
@@ -10957,7 +10957,7 @@ fn patch_sheegoth_scale<'r>(
 
 fn patch_flaahgra_scale<'r>(
     _ps: &mut PatcherState,
-    area: &mut mlvl_wrapper::MlvlArea<'r, '_, '_, '_, '_>,
+    area: &mut mlvl_wrapper::MlvlArea<'r, '_, '_, '_>,
     scale: f32,
 )
 -> Result<(), String>
@@ -10980,7 +10980,7 @@ fn patch_flaahgra_scale<'r>(
 
 fn patch_idrone_scale<'r>(
     _ps: &mut PatcherState,
-    area: &mut mlvl_wrapper::MlvlArea<'r, '_, '_, '_, '_>,
+    area: &mut mlvl_wrapper::MlvlArea<'r, '_, '_, '_>,
     scale: f32,
 )
 -> Result<(), String>
@@ -11001,7 +11001,7 @@ fn patch_idrone_scale<'r>(
 
 fn patch_pq_scale<'r>(
     _ps: &mut PatcherState,
-    area: &mut mlvl_wrapper::MlvlArea<'r, '_, '_, '_, '_>,
+    area: &mut mlvl_wrapper::MlvlArea<'r, '_, '_, '_>,
     scale: f32,
 )
 -> Result<(), String>
@@ -11031,7 +11031,7 @@ fn patch_pq_scale<'r>(
 
 fn patch_thardus_scale<'r>(
     _ps: &mut PatcherState,
-    area: &mut mlvl_wrapper::MlvlArea<'r, '_, '_, '_, '_>,
+    area: &mut mlvl_wrapper::MlvlArea<'r, '_, '_, '_>,
     scale: f32,
 )
 -> Result<(), String>
@@ -11061,7 +11061,7 @@ fn patch_thardus_scale<'r>(
 
 fn patch_essence_scale<'r>(
     _ps: &mut PatcherState,
-    area: &mut mlvl_wrapper::MlvlArea<'r, '_, '_, '_, '_>,
+    area: &mut mlvl_wrapper::MlvlArea<'r, '_, '_, '_>,
     scale: f32,
 )
 -> Result<(), String>
@@ -11102,7 +11102,7 @@ fn patch_essence_scale<'r>(
 
 fn patch_drone_scale<'r>(
     _ps: &mut PatcherState,
-    area: &mut mlvl_wrapper::MlvlArea<'r, '_, '_, '_, '_>,
+    area: &mut mlvl_wrapper::MlvlArea<'r, '_, '_, '_>,
     scale: f32,
 )
 -> Result<(), String>
@@ -11123,7 +11123,7 @@ fn patch_drone_scale<'r>(
 
 fn patch_garbeetle_scale<'r>(
     _ps: &mut PatcherState,
-    area: &mut mlvl_wrapper::MlvlArea<'r, '_, '_, '_, '_>,
+    area: &mut mlvl_wrapper::MlvlArea<'r, '_, '_, '_>,
     scale: f32,
 )
 -> Result<(), String>
@@ -12239,7 +12239,7 @@ fn patch_hive_mecha<'a>(patcher: &mut PrimePatcher<'_, 'a>)
     });
 }
 
-fn patch_incinerator_drone_timer<'r>(area: &mut mlvl_wrapper::MlvlArea<'r, '_, '_, '_, '_>, timer_name: CString, minimum_time: Option<f32>, random_add: Option<f32>) -> Result<(), String> {
+fn patch_incinerator_drone_timer<'r>(area: &mut mlvl_wrapper::MlvlArea<'r, '_, '_, '_>, timer_name: CString, minimum_time: Option<f32>, random_add: Option<f32>) -> Result<(), String> {
     let scly = area.mrea().scly_section_mut();
 
     let layer = &mut scly.layers.as_mut_vec()[0]; // Default

--- a/src/patches.rs
+++ b/src/patches.rs
@@ -180,7 +180,7 @@ fn build_artifact_temple_totem_scan_strings<R>(
             if room.pickups.is_none() { continue };
             for pickup in room.pickups.as_ref().unwrap().iter() {
                 let pickup_type = PickupType::from_str(&pickup.pickup_type);
-                if pickup_type.kind() >= PickupType::ArtifactOfLifegiver.kind() && pickup_type.kind() <= PickupType::ArtifactOfStrength.kind() {
+                if pickup_type.kind() >= PickupType::ArtifactOfTruth.kind() && pickup_type.kind() <= PickupType::ArtifactOfNewborn.kind() {
                     artifact_locations.push((&room_name.as_str(), pickup_type));
                 }
             }
@@ -207,7 +207,24 @@ fn build_artifact_temple_totem_scan_strings<R>(
 
     // Shame there isn't a way to flatten tuples automatically
     for (room_name, pt) in artifact_locations.iter() {
-        let artifact_id = (pt.kind() - PickupType::ArtifactOfLifegiver.kind()) as usize;
+        let artifact_id = (pt.kind() - PickupType::ArtifactOfTruth.kind()) as usize;
+
+        let artifact_id = match artifact_id {
+            0  => 6 , // ArtifactOfTruth
+            1  => 11, // ArtifactOfStrength
+            2  => 4 , // ArtifactOfElder
+            3  => 1 , // ArtifactOfWild
+            4  => 0 , // ArtifactOfLifegive
+            5  => 8 , // ArtifactOfWarrior
+            6  => 7 , // ArtifactOfChozo
+            7  => 10, // ArtifactOfNature
+            8  => 3 , // ArtifactOfSun
+            9  => 2 , // ArtifactOfWorld
+            10 => 5 , // ArtifactOfSpirit
+            11 => 9 , // ArtifactOfNewborn
+            _ => panic!("Error - Bad artifact id '{}'", artifact_id)
+        };
+
         if scan_text[artifact_id].len() != 0 {
             // If there are multiple of this particular artifact, then we use the first instance
             // for the location of the artifact.
@@ -2998,10 +3015,10 @@ fn modify_pickups_in_mrea<'r>(
 
     if pickup_type == PickupType::FloatyJump {
         floaty_contraption_id = [
-            area.new_object_id_from_layer_name("Default"),
-            area.new_object_id_from_layer_name("Default"),
-            area.new_object_id_from_layer_name("Default"),
-            area.new_object_id_from_layer_name("Default"),
+            area.new_object_id_from_layer_id(0),
+            area.new_object_id_from_layer_id(0),
+            area.new_object_id_from_layer_id(0),
+            area.new_object_id_from_layer_id(0),
         ];
     }
 
@@ -3300,7 +3317,7 @@ fn modify_pickups_in_mrea<'r>(
 
     if pickup_type == PickupType::FloatyJump {
         place_floaty_contraption(
-            layers[pickup_location.location.layer as usize].objects.as_mut_vec(),
+            layers[0].objects.as_mut_vec(),
             floaty_contraption_id[0],
             floaty_contraption_id[1],
             floaty_contraption_id[2],
@@ -3459,6 +3476,13 @@ fn place_floaty_contraption<'r>(
     position: [f32;3],
 )
 {
+    if timer1_id == 0 || timer2_id == 0 || water_id == 0 || camera_id == 0 ||
+        timer1_id == timer2_id || timer1_id == water_id || timer1_id == camera_id ||
+        timer2_id == water_id || timer2_id == camera_id || water_id == camera_id
+    {
+        panic!("something went wrong making floaty contraption");
+    }
+
     let mut water_obj = WaterType::Normal.to_obj();
     water_obj.instance_id = water_id;
 

--- a/structs/src/savw.rs
+++ b/structs/src/savw.rs
@@ -24,7 +24,7 @@ pub struct Savw<'r>
     #[auto_struct(derive = memory_relay_array.len() as u32)]
     memory_relay_count: u32,
     #[auto_struct(init = (memory_relay_count as usize, ()))]
-    pub memory_relay_array: LazyArray<'r, u32>,
+    pub memory_relay_array: RoArray<'r, u32>,
 
     #[auto_struct(derive = layer_toggle_array.len() as u32)]
     layer_toggle_count: u32,


### PR DESCRIPTION
Until a stable fix that resolves infinite scans, instant scans, and memory relay non-volatile coherence, they will be removed.
