### PR TITLE
Implemented poison damage per second patch

### DIFF
--- a/src/patch_config.rs
+++ b/src/patch_config.rs
@@ -575,6 +575,7 @@ pub struct PatchConfig
     pub remove_vanilla_blast_shields: bool,
     pub nonvaria_heat_damage: bool,
     pub heat_damage_per_sec: f32,
+    pub poison_damage_per_sec: f32,
     pub staggered_suit_damage: bool,
     pub item_max_capacity: HashMap<PickupType, u32>,
     // Use RoomConfig::map_default_state instead of global map_default_state
@@ -663,6 +664,7 @@ struct GameConfig
     nonvaria_heat_damage: Option<bool>,
     staggered_suit_damage: Option<bool>,
     heat_damage_per_sec: Option<f32>,
+    poison_damage_per_sec: Option<f32>,
     auto_enabled_elevators: Option<bool>,
     multiworld_dol_patches: Option<bool>,
     update_hint_state_replacement: Option<Vec<u8>>,
@@ -880,6 +882,10 @@ impl PatchConfig
                 .long("heat-damage-per-sec")
                 .help("Set the heat damage per seconds spent in a superheated room")
                 .takes_value(true))
+            .arg(Arg::with_name("poison damage per sec")
+                .long("poison-damage-per-sec")
+                .help("Set the poison damage per seconds spent in poison water")
+                .takes_value(true))
             .arg(Arg::with_name("staggered suit damage")
                 .long("staggered-suit-damage")
                 .help(concat!("The suit damage reduction is determinted by the number of suits ",
@@ -997,6 +1003,9 @@ impl PatchConfig
         }
         if let Some(damage) = matches.value_of("heat damage per sec") {
             patch_config.game_config.heat_damage_per_sec = Some(damage.parse::<f32>().unwrap());
+        }
+        if let Some(damage) = matches.value_of("poison damage per sec") {
+            patch_config.game_config.poison_damage_per_sec = Some(damage.parse::<f32>().unwrap());
         }
         if let Some(etank_capacity) = matches.value_of("etank capacity") {
             patch_config.game_config.etank_capacity = Some(etank_capacity.parse::<u32>().unwrap());
@@ -1274,6 +1283,7 @@ impl PatchConfigPrivate
             nonvaria_heat_damage: self.game_config.nonvaria_heat_damage.unwrap_or(false),
             staggered_suit_damage: self.game_config.staggered_suit_damage.unwrap_or(false),
             heat_damage_per_sec: self.game_config.heat_damage_per_sec.unwrap_or(10.0),
+            poison_damage_per_sec: self.game_config.poison_damage_per_sec.unwrap_or(0.11),
             auto_enabled_elevators: self.game_config.auto_enabled_elevators.unwrap_or(false),
             multiworld_dol_patches: self.game_config.multiworld_dol_patches.unwrap_or(false),
             update_hint_state_replacement: self.game_config.update_hint_state_replacement.clone(),


### PR DESCRIPTION
Allows to change the poison damage per seconds in every rooms that contain poisoned water (even if the layer is unused such as Chozo Ruins - Magma Pool).

Default value is 0.11 HP/sec which is the US value. PAL value is 0.25HP/sec.