### PR TITLE
More tweaks for PAL/JP versions

### DIFF
--- a/structs/src/scly_props/new_intro_boss.rs
+++ b/structs/src/scly_props/new_intro_boss.rs
@@ -3,6 +3,7 @@ use auto_struct_macros::auto_struct;
 use reader_writer::CStr;
 use reader_writer::typenum::*;
 use reader_writer::generic_array::GenericArray;
+use crate::res_id:: *;
 use crate::{SclyPropertyData};
 use crate::scly_props::structs::{ActorParameters, DamageInfo, PatternedInfo};
 
@@ -25,7 +26,8 @@ pub struct NewIntroBoss<'r>
     pub weapon_desc: f32,
     pub damage_info: DamageInfo,
 
-    pub dont_care: GenericArray<u32, U4>,
+    pub particles: GenericArray<ResId<PART>, U2>,
+    pub textures: GenericArray<ResId<TXTR>, U2>,
 }
 
 impl<'r> SclyPropertyData for NewIntroBoss<'r>

--- a/structs/src/scly_props/ridley_v1.rs
+++ b/structs/src/scly_props/ridley_v1.rs
@@ -3,7 +3,9 @@ use auto_struct_macros::auto_struct;
 use reader_writer::CStr;
 use reader_writer::typenum::*;
 use reader_writer::generic_array::GenericArray;
+use crate::res_id:: *;
 use crate::{SclyPropertyData};
+use crate::scly_props::structs::{ActorParameters, DamageInfo, PatternedInfo, RidleyStruct1, RidleyStruct2};
 
 #[auto_struct(Readable, Writable)]
 #[derive(Debug, Clone)]
@@ -18,7 +20,42 @@ pub struct RidleyV1<'r>
     pub rotation: GenericArray<f32, U3>,
     pub scale: GenericArray<f32, U3>,
 
-    pub dont_care: GenericArray<u8, U917>,
+    pub patterned_info: PatternedInfo,
+    pub actor_params: ActorParameters,
+
+    pub models: GenericArray<ResId<CMDL>, U12>,
+    pub particle: ResId<PART>,
+
+    pub unknown0: f32,
+    pub unknown1: f32,
+    pub unknown2: f32,
+    pub unknown3: f32,
+
+    pub wpsc0: u32, // missing ResId<WPSC>
+    pub damage_info0: DamageInfo,
+    pub ridley_struct_0: RidleyStruct1,
+    pub sound0: u32,
+    pub wpsc1: u32, // missing ResId<WPSC>
+    pub damage_info1: DamageInfo,
+    pub ridley_struct_1: RidleyStruct2,
+    pub wpsc2: u32, // missing ResId<WPSC>
+    pub damage_info2: DamageInfo,
+    pub ridley_struct_2: RidleyStruct2,
+    pub sound1: u32, // missing ResId<WPSC>
+    pub damage_info3: DamageInfo,
+    pub ridley_struct_3: RidleyStruct2,
+    pub unknown4: f32,
+    pub unknown5: f32,
+    pub damage_info4: DamageInfo,
+    pub unknown6: f32,
+    pub damage_info5: DamageInfo,
+    pub unknown7: f32,
+    pub damage_info6: DamageInfo,
+    pub unknown8: f32,
+    pub elsc: u32,
+    pub unknown9: f32,
+    pub sound2: u32,
+    pub damage_info7: DamageInfo,
 }
 
 impl<'r> SclyPropertyData for RidleyV1<'r>

--- a/structs/src/scly_props/ridley_v2.rs
+++ b/structs/src/scly_props/ridley_v2.rs
@@ -3,7 +3,9 @@ use auto_struct_macros::auto_struct;
 use reader_writer::CStr;
 use reader_writer::typenum::*;
 use reader_writer::generic_array::GenericArray;
+use crate::res_id:: *;
 use crate::{SclyPropertyData};
+use crate::scly_props::structs::{ActorParameters, DamageInfo, PatternedInfo, RidleyStruct1, RidleyStruct2};
 
 #[auto_struct(Readable, Writable)]
 #[derive(Debug, Clone)]
@@ -18,7 +20,44 @@ pub struct RidleyV2<'r>
     pub rotation: GenericArray<f32, U3>,
     pub scale: GenericArray<f32, U3>,
 
-    pub dont_care: GenericArray<u8, U901>,
+    pub patterned_info: PatternedInfo,
+    pub actor_params: ActorParameters,
+
+    pub models: GenericArray<ResId<CMDL>, U2>,
+    pub particle: ResId<PART>,
+
+    pub unknown0: f32,
+    pub unknown1: f32,
+    pub unknown2: f32,
+    pub unknown3: f32,
+
+    pub wpsc0: u32, // missing ResId<WPSC>
+    pub damage_info0: DamageInfo,
+    pub ridley_struct_0: RidleyStruct1,
+    pub sound0: u32,
+    pub wpsc1: u32, // missing ResId<WPSC>
+    pub wpsc2: u32, // missing ResId<WPSC>
+    pub damage_info1: DamageInfo,
+    pub ridley_struct_1: RidleyStruct2,
+    pub wpsc3: u32, // missing ResId<WPSC>
+    pub damage_info2: DamageInfo,
+    pub ridley_struct_2: RidleyStruct2,
+    pub sound1: u32, // missing ResId<WPSC>
+    pub damage_info3: DamageInfo,
+    pub ridley_struct_3: RidleyStruct2,
+    pub unknown4: f32,
+    pub unknown5: f32,
+    pub damage_info4: DamageInfo,
+    pub unknown6: f32,
+    pub damage_info5: DamageInfo,
+    pub unknown7: f32,
+    pub damage_info6: DamageInfo,
+    pub unknown8: f32,
+    pub elsc: u32,
+    pub unknown9: f32,
+    pub sound2: u32,
+    pub damage_info7: DamageInfo,
+    pub damage_info8: DamageInfo,
 }
 
 impl<'r> SclyPropertyData for RidleyV2<'r>

--- a/structs/src/scly_props/structs.rs
+++ b/structs/src/scly_props/structs.rs
@@ -95,7 +95,7 @@ pub struct VisorParameters
 }
 
 #[auto_struct(Readable, Writable, FixedSize)]
-#[derive(Debug, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct DamageInfo
 {
     #[auto_struct(expect = 4)]
@@ -231,4 +231,40 @@ pub struct PatternedInfo
     pub particle1_scale: GenericArray<f32, U3>,
     pub particle1: ResId<PART>,
     pub ice_shatter_sfx: u32,
+}
+
+#[auto_struct(Readable, Writable, FixedSize)]
+#[derive(Debug, Clone)]
+pub struct RidleyStruct1
+{
+    pub unknown0: u32,
+    pub unknown1: u32,
+    pub particles: GenericArray<ResId<PART>, U2>,
+    pub textures: GenericArray<ResId<TXTR>, U2>,
+    pub unknown2: f32,
+    pub unknown3: f32,
+    pub unknown4: f32,
+    pub unknown5: f32,
+    pub unknown6: f32,
+    pub unknown7: f32,
+    pub unknown8: f32,
+    pub unknown9: f32,
+    pub unknown10: f32,
+    pub color0: GenericArray<f32, U4>,
+    pub color1: GenericArray<f32, U4>,
+}
+
+#[auto_struct(Readable, Writable, FixedSize)]
+#[derive(Debug, Clone)]
+pub struct RidleyStruct2
+{
+    pub unknown0: u32,
+    pub unknown1: f32,
+    pub unknown2: f32,
+    pub unknown3: f32,
+    pub unknown4: f32,
+    pub unknown5: f32,
+    pub unknown6: f32,
+    pub unknown7: f32,
+    pub unknown8: u8,
 }


### PR DESCRIPTION
# Ridley now has partially its properties set to NTSC-U 0-00

Ridley now has its health back to 2000 (3000 on PAL and 2500 on Trilogy)
Each attacks are back to the default values of NTSC-U 0-00 (except damage info 8 which is the new stomp attack from Ridley)

Note : Ridley still requires to be changed to set the stun requirements back to NTSC-U 0-00 and also for the boost ball and wavebuster vulnerabilities

# Parasite Queen now has its health set to NTSC-U 0-00 value

Parasite Queen has its health back to 480 (500 on PAL)

# Essence now has its health set to NTSC-U 0-00 value

Essence has its health back to 36667 (50000 on PAL)