### PR TITLE
Print STDERR nicer for PPC panic

### DIFF
--- a/generated/rel_files/build.rs
+++ b/generated/rel_files/build.rs
@@ -33,7 +33,7 @@ fn invoke_cargo(ppc_manifest: &Path, package: &str)
         .output()
         .expect("Failed to compile ppc crate");
     if !output.status.success() {
-        panic!("{:#?}", output);
+        panic!("{:#?}", output.stderr);
     }
 }
 


### PR DESCRIPTION
if the debug output of `output` is printed, then it's not only very ugly (as it's a completely unformatted string), but also makes it harder to follow what the actual error is. Aka something like this:
```
<U3>>::Output;\n     |     ------------------------------------------------------ similarly named type alias `T2` defined here\n...\n1168 |     type T5 = <SetBitOut<U2, U2, B0> as Same<U2>>::Output;\n     |                              ^^\n     |\nhelp: a type alias with a similar name exists\n     |\n1168 |     type T5 = <SetBitOut<U2, T2, B0> as Same<U2>>::Output;\n     |                              ~~\nhelp: you might be missing a type parameter\n     |\n1168 |     type T5<U2> = <SetBitOut<U2, U2, B0> as Same<U2>>::Output;\n     |            ++++\n\nerror[E0412]: cannot find type `U2` in this scope\n    --> /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/typenum-1.11.2/src/uint.rs:1168:46\n     |\n1165 |     type T2 = <SetBitOut<U2, U0, B1> as Same<U3>>::Output;\n     |     ------------------------------------------------------ similarly named type alias `T2` defined here\n...\n1168 |     type T5 = <SetBitOut<U2, U2, B0> as Same<U2>>::Output;\n     |                                              ^^\n     |\nhelp: a type alias with a similar name exists\n     |\n1168 |     type T5 = <SetBitOut<U2, U2, B0> as Same<T2>>::Output;\n     |                                              ~~\nhelp: you might be missing a type parameter\n     |\n1168 |     type T5<U2> = <SetBitOut<U2, U2, B0> as Same<U2>>::Output;\n     |            ++++\n\nerror[E0412]: cannot find type `U2` in this scope\n    --> /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/typenum-1.11.2/src/uint.rs:1169:26\n     |\n1165 |     type T2 = <SetBitOut<U2, U0, B1> as Same<U3>>::Output;\n     |     ------------------------------------------------------ similarly named type alias `T2` defined here\n...\n1169 |     type T6 = <SetBitOut<U2, U2, B1> as Same<U6>>::Output;\n     |                          ^^\n     |\nhelp: a type alias with a similar name exists\n     |\n1169 |     type T6 = <SetBitOut<T2, U2, B1> as Same<U6>>::Output;\n     |                          ~~\nhelp: you m
```

